### PR TITLE
Add CI workflow with FastAPI demo app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run tests
+        run: |
+          pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+venv/

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, world!"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn[standard]
+pytest

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,9 @@
+import unittest
+from app.main import app, read_root
+
+class TestAuth(unittest.TestCase):
+    def test_read_root(self):
+        self.assertEqual(read_root(), {"message": "Hello, world!"})
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow running on Python 3.11
- add minimal FastAPI application
- add unit test for the root endpoint
- include requirements and .gitignore

## Testing
- `python -m unittest discover -s tests -v`