### PR TITLE
Fix GitHub CI test imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,4 +16,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run tests
-        run: pytest
+        run: |
+          # Add the repository root to PYTHONPATH so the `app` package is importable
+          export PYTHONPATH="$PWD"
+          pytest


### PR DESCRIPTION
## Summary
- ensure the `app` package is on `PYTHONPATH` during CI

## Testing
- `venv/bin/python -m pytest -q`
