### PR TITLE
Enable optional PostgreSQL testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,26 @@
 name: CI
 
 on:
+  push:
   pull_request:
 
 jobs:
   test:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: testdb
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -16,7 +31,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run tests
+        env:
+          TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/testdb
         run: |
-          # Add the repository root to PYTHONPATH so the `app` package is importable
           export PYTHONPATH="$PWD"
           pytest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository contains a small FastAPI application with user authentication.
 
 ## Features
 - Sign in page
-- SQLite database for storing users
+- SQLite database for storing users by default
+- Optional PostgreSQL support via the `DATABASE_URL` environment variable
 - Protected page that greets authenticated users
 
 ## Development
@@ -13,6 +14,14 @@ Run the setup script to create a virtual environment and install dependencies:
 ```bash
 ./setup.sh
 source venv/bin/activate
+```
+
+The setup script attempts to install and start a local PostgreSQL server if
+`apt-get` is available. The application will use SQLite unless the
+`DATABASE_URL` environment variable is set. For development, you can run
+
+```bash
+export DATABASE_URL=postgresql://postgres:postgres@localhost:5432/postgres
 ```
 
 Run the application:
@@ -34,7 +43,15 @@ Build and run:
 
 ```bash
 docker build -t codex-playground .
-docker run -p 8000:80 codex-playground
+docker run -e DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres \
+  -p 8000:80 codex-playground
+```
+
+The example above expects a PostgreSQL instance reachable at the hostname `db`.
+For local development you can run a Postgres container with:
+
+```bash
+docker run --name db -e POSTGRES_PASSWORD=postgres -p 5432:5432 -d postgres:15
 ```
 
 Visit `http://localhost:8000/login` to sign in.

--- a/app/database.py
+++ b/app/database.py
@@ -1,11 +1,18 @@
+"""Database configuration module."""
+
+import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
+SQLALCHEMY_DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./test.db")
 
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
-)
+if SQLALCHEMY_DATABASE_URL.startswith("sqlite"):
+    engine = create_engine(
+        SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    )
+else:
+    engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ passlib[bcrypt]
 pytest
 httpx
 itsdangerous
+psycopg2-binary

--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Install PostgreSQL if available (may require sudo privileges)
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y postgresql
+    sudo service postgresql start
+fi
+
 # Create Python virtual environment for the project
 python3 -m venv venv
 
@@ -9,14 +16,6 @@ source venv/bin/activate
 
 # Upgrade pip and install required packages
 python -m pip install --upgrade pip
-pip install fastapi \
-    uvicorn \
-    sqlalchemy \
-    jinja2 \
-    python-multipart \
-    "passlib[bcrypt]" \
-    pytest \
-    httpx \
-    itsdangerous
+pip install -r requirements.txt
 
 echo "Environment setup complete. Activate with 'source venv/bin/activate'"

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -15,11 +16,16 @@ from app.main import app
 from app.database import Base, get_db
 from app import models, auth
 
-engine = create_engine(
-    "sqlite://",
-    connect_args={"check_same_thread": False},
-    poolclass=StaticPool,
-)
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+
+if TEST_DATABASE_URL:
+    engine = create_engine(TEST_DATABASE_URL)
+else:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
## Summary
- allow database connection to be set via `DATABASE_URL`
- add optional Postgres installation in `setup.sh`
- support Postgres in tests via `TEST_DATABASE_URL`
- run PostgreSQL service in CI workflow
- document how to use Postgres for development and Docker
- include `psycopg2-binary` requirement

## Testing
- `source venv/bin/activate && export PYTHONPATH=$PWD && pytest -q`