### PR TITLE
Add script to purge LLVM apt entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ This repository contains a small FastAPI application with user authentication.
 - Protected page that greets authenticated users
 
 ## Development
-Run the setup script to create a virtual environment and install dependencies:
+Run the setup script to create a virtual environment and install dependencies.
+The script also cleans up any `apt.llvm.org` entries from the system's APT
+sources before installing Docker:
 
 ```bash
 ./setup.sh

--- a/remove_llvm_source.sh
+++ b/remove_llvm_source.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Remove references to apt.llvm.org from APT sources
+
+echo "Cleaning apt.llvm.org entries from APT sources..."
+
+sudo sed -i '/apt\.llvm\.org/d' /etc/apt/sources.list || true
+
+if [ -d /etc/apt/sources.list.d ]; then
+  while IFS= read -r -d '' file; do
+    sudo sed -i '/apt\.llvm\.org/d' "$file" || true
+  done < <(find /etc/apt/sources.list.d -type f -print0)
+fi
+

--- a/setup.sh
+++ b/setup.sh
@@ -25,16 +25,18 @@ pip install fastapi \
     itsdangerous \
     psycopg2-binary
 
-# # Install Docker if apt-get is available
-# echo "Checking for apt-get to install Docker..."
-# if command -v apt-get >/dev/null; then
-#     echo "Running apt-get update..."
-#     sudo apt-get update
-#     echo "Installing docker.io via apt-get..."
-#     sudo apt-get install -y docker.io
-# else
-#     echo "apt-get not found; skipping Docker installation."
-# fi
+# Install Docker if apt-get is available
+echo "Checking for apt-get to install Docker..."
+if command -v apt-get >/dev/null; then
+    echo "Removing any apt.llvm.org sources..."
+    ./remove_llvm_source.sh
+    echo "Running apt-get update..."
+    sudo apt-get update
+    echo "Installing docker.io via apt-get..."
+    sudo apt-get install -y docker.io
+else
+    echo "apt-get not found; skipping Docker installation."
+fi
 
 # # Set database environment variables for PostgreSQL
 # echo "Configuring PostgreSQL environment variables..."


### PR DESCRIPTION
## Summary
- add `remove_llvm_source.sh` to purge `apt.llvm.org` references
- call script from `setup.sh` before running apt-get update
- document new cleanup step in README

## Testing
- `python -m pytest -q`