### PR TITLE
Add dark mode toggle tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,47 @@
+import os
+import warnings
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from app.main import app
+from app.database import Base, get_db
+
+warnings.filterwarnings(
+    "ignore",
+    message="'crypt' is deprecated",
+    category=DeprecationWarning,
+    module="passlib",
+)
+
+TEST_DATABASE_URL = os.getenv("TEST_DATABASE_URL")
+
+if TEST_DATABASE_URL:
+    engine = create_engine(TEST_DATABASE_URL)
+else:
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c

--- a/tests/test_darkmode.py
+++ b/tests/test_darkmode.py
@@ -1,0 +1,38 @@
+def test_darkmode_toggle_in_login_page(client):
+    response = client.get("/login")
+    assert response.status_code == 200
+    assert 'id="toggle-dark"' in response.text
+    assert 'applyDarkMode' in response.text
+    assert "localStorage.getItem('darkMode')" in response.text
+
+
+def test_darkmode_toggle_in_signup_page(client):
+    response = client.get("/signup")
+    assert response.status_code == 200
+    assert 'id="toggle-dark"' in response.text
+    assert 'applyDarkMode' in response.text
+
+
+def test_darkmode_toggle_in_protected_page_after_login(client):
+    username = "darktoggle"
+    password = "secret"
+
+    # create user if not exists
+    client.post(
+        "/signup",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+
+    response = client.post(
+        "/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    client.cookies.update(response.cookies)
+
+    response = client.get("/protected")
+    assert response.status_code == 200
+    assert 'id="toggle-dark"' in response.text
+    assert 'applyDarkMode' in response.text


### PR DESCRIPTION
## Summary
- add a pytest fixture in `conftest.py` for shared database and TestClient
- update auth tests to use the fixture
- add tests that ensure dark mode toggle elements appear on login, signup, and protected pages

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`