### PR TITLE
Add login failure redirect with warning

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -50,7 +50,8 @@ def signup(
 
 @app.get("/login", response_class=HTMLResponse)
 def login_form(request: Request):
-    return templates.TemplateResponse(request, "login.html")
+    error = request.query_params.get("error")
+    return templates.TemplateResponse(request, "login.html", {"error": error})
 
 
 @app.post("/login")
@@ -62,7 +63,8 @@ def login(
 ):
     user = db.query(models.User).filter(models.User.username == username).first()
     if not user or not auth.verify_password(password, user.hashed_password):
-        raise HTTPException(status_code=400, detail="Invalid credentials")
+        url = app.url_path_for("login_form") + "?error=Invalid%20credentials"
+        return RedirectResponse(url=url, status_code=303)
     request.session["user_id"] = user.id
     return RedirectResponse(url="/protected", status_code=303)
 

--- a/templates/login.html
+++ b/templates/login.html
@@ -57,6 +57,9 @@
     <div class="login-container">
       <h1>Login</h1>
       <button id="toggle-dark" type="button">Toggle Dark Mode</button>
+      {% if error %}
+      <p style="color: red">{{ error }}</p>
+      {% endif %}
       <form action="/login" method="post">
         <label>
           Username:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -62,3 +62,24 @@ def test_login_success(client):
     response = client.get("/protected")
     assert response.status_code == 200
     assert "Congrats! You signed in!" in response.text
+
+
+def test_login_failure_redirect(client):
+    client.post(
+        "/signup",
+        data={"username": "eve", "password": "secret"},
+        follow_redirects=False,
+    )
+
+    response = client.post(
+        "/login",
+        data={"username": "eve", "password": "wrong"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/login")
+    assert "error=Invalid%20credentials" in response.headers["location"]
+
+    response = client.get(response.headers["location"])
+    assert response.status_code == 200
+    assert "Invalid credentials" in response.text


### PR DESCRIPTION
## Summary
- redirect back to login page with an error when credentials are wrong
- display login error message in template
- test invalid login redirect

## Testing
- `./venv/bin/python -m pytest -q`