### PR TITLE
Add cat photo for logged in users

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
+import time
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 from sqlalchemy.orm import Session
@@ -71,10 +72,11 @@ def login(
 
 @app.get("/protected", response_class=HTMLResponse)
 def protected(request: Request, user: models.User = Depends(get_current_user)):
+    cat_url = f"https://cataas.com/cat?{int(time.time())}"
     return templates.TemplateResponse(
         request,
         "success.html",
-        {"username": user.username},
+        {"username": user.username, "cat_url": cat_url},
     )
 
 

--- a/templates/success.html
+++ b/templates/success.html
@@ -41,6 +41,7 @@
     <div class="success-container">
       <h1>Congrats! You signed in!</h1>
       <p>Welcome {{ username }}!</p>
+      <img id="cat-photo" src="{{ cat_url }}" alt="Random Cat" />
       <button id="toggle-dark" type="button">Toggle Dark Mode</button>
       <a href="/logout">Logout</a>
     </div>

--- a/tests/test_cat_photo.py
+++ b/tests/test_cat_photo.py
@@ -1,0 +1,27 @@
+import re
+
+
+def test_cat_photo_display_after_login(client):
+    username = "catuser"
+    password = "secret"
+
+    client.post(
+        "/signup",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+
+    response = client.post(
+        "/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    client.cookies.update(response.cookies)
+
+    response = client.get("/protected")
+    assert response.status_code == 200
+    assert 'id="cat-photo"' in response.text
+    match = re.search(r'<img[^>]+id="cat-photo"[^>]+src="([^"]+)"', response.text)
+    assert match, "cat photo img tag with src not found"
+    assert match.group(1).startswith("https://cataas.com/cat?")


### PR DESCRIPTION
## Summary
- show a random cat photo on the protected page
- include cat URL in the handler
- test that the cat photo is displayed after login

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`