### PR TITLE
Add Nashville forecast endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import Depends, FastAPI, Form, HTTPException, Request, status
 from fastapi.responses import HTMLResponse, RedirectResponse
+import httpx
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.sessions import SessionMiddleware
 from sqlalchemy.orm import Session
@@ -87,3 +88,22 @@ def logout(request: Request):
 @app.get("/", response_class=HTMLResponse)
 def root(request: Request):
     return templates.TemplateResponse("login.html", {"request": request})
+
+
+@app.get("/forecast/nashville")
+def nashville_forecast():
+    """Return Nashville's 7 day weather forecast from Open-Meteo."""
+    response = httpx.get(
+        "https://api.open-meteo.com/v1/forecast",
+        params={
+            "latitude": 36.1627,
+            "longitude": -86.7816,
+            "daily": "temperature_2m_max,temperature_2m_min",
+            "forecast_days": 7,
+            "temperature_unit": "fahrenheit",
+            "timezone": "America/Chicago",
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+    return response.json()

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,0 +1,37 @@
+import httpx
+
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def test_nashville_forecast_endpoint(monkeypatch):
+    expected = {
+        "daily": {
+            "time": ["2025-05-20", "2025-05-21", "2025-05-22", "2025-05-23", "2025-05-24", "2025-05-25", "2025-05-26"],
+            "temperature_2m_max": [70, 71, 72, 73, 74, 75, 76],
+            "temperature_2m_min": [50, 51, 52, 53, 54, 55, 56],
+        }
+    }
+
+    class MockResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+        def raise_for_status(self):
+            pass
+
+    def mock_get(url, params=None, timeout=None):
+        assert url == "https://api.open-meteo.com/v1/forecast"
+        assert params["latitude"] == 36.1627
+        assert params["longitude"] == -86.7816
+        return MockResponse(expected)
+
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    client = TestClient(app)
+    response = client.get("/forecast/nashville")
+    assert response.status_code == 200
+    assert response.json() == expected


### PR DESCRIPTION
## Summary
- add new route to fetch 7-day Nashville forecast from Open-Meteo
- test the forecast endpoint with patched httpx

## Testing
- `venv/bin/python -m pytest -q`