### PR TITLE
Add HTML forecast page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -92,9 +92,9 @@ def root(request: Request):
     return templates.TemplateResponse("login.html", {"request": request})
 
 
-@app.get("/forecast/nashville")
-def nashville_forecast():
-    """Return Nashville's 7 day weather forecast from Open-Meteo."""
+@app.get("/forecast/nashville", response_class=HTMLResponse)
+def nashville_forecast(request: Request):
+    """Return Nashville's 7 day weather forecast from Open-Meteo as a web page."""
     response = httpx.get(
         "https://api.open-meteo.com/v1/forecast",
         params={
@@ -108,4 +108,14 @@ def nashville_forecast():
         timeout=10,
     )
     response.raise_for_status()
-    return response.json()
+    data = response.json()
+    forecast = list(
+        zip(
+            data["daily"]["time"],
+            data["daily"]["temperature_2m_max"],
+            data["daily"]["temperature_2m_min"],
+        )
+    )
+    return templates.TemplateResponse(
+        "forecast.html", {"request": request, "forecast": forecast}
+    )

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Nashville Forecast</title>
+    <style>
+      :root {
+        --bg-color: #f5f5f5;
+        --text-color: #000;
+        --container-bg: white;
+        --link-color: #007bff;
+      }
+      .dark-mode {
+        --bg-color: #222;
+        --text-color: #eee;
+        --container-bg: #333;
+        --link-color: #66b0ff;
+      }
+      body {
+        font-family: Arial, sans-serif;
+        background-color: var(--bg-color);
+        color: var(--text-color);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        height: 100vh;
+        margin: 0;
+      }
+      .forecast-container {
+        background: var(--container-bg);
+        padding: 2rem;
+        border-radius: 8px;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+        text-align: center;
+      }
+      table {
+        margin-top: 1rem;
+        border-collapse: collapse;
+        width: 100%;
+      }
+      th, td {
+        border: 1px solid #ccc;
+        padding: 0.5rem;
+      }
+      a {
+        color: var(--link-color);
+      }
+    </style>
+  </head>
+  <body>
+    <div class="forecast-container">
+      <h1>Nashville 7-Day Forecast</h1>
+      <button id="toggle-dark" type="button">Toggle Dark Mode</button>
+      <table>
+        <thead>
+          <tr><th>Date</th><th>High</th><th>Low</th></tr>
+        </thead>
+        <tbody>
+          {% for date, high, low in forecast %}
+          <tr><td>{{ date }}</td><td>{{ high }}&deg;F</td><td>{{ low }}&deg;F</td></tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      <p><a href="/">Back to Login</a></p>
+    </div>
+    <script>
+      function applyDarkMode(on) {
+        if (on) {
+          document.body.classList.add('dark-mode');
+        } else {
+          document.body.classList.remove('dark-mode');
+        }
+      }
+
+      const dark = localStorage.getItem('darkMode') === 'true';
+      applyDarkMode(dark);
+
+      document.getElementById('toggle-dark').addEventListener('click', () => {
+        const enabled = document.body.classList.toggle('dark-mode');
+        localStorage.setItem('darkMode', enabled);
+      });
+    </script>
+  </body>
+</html>

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -34,4 +34,5 @@ def test_nashville_forecast_endpoint(monkeypatch):
     client = TestClient(app)
     response = client.get("/forecast/nashville")
     assert response.status_code == 200
-    assert response.json() == expected
+    assert "Nashville 7-Day Forecast" in response.text
+    assert expected["daily"]["time"][0] in response.text


### PR DESCRIPTION
## Summary
- add new endpoint handler to render Nashville forecast as a template
- create `forecast.html` for displaying seven day forecast
- adjust tests for new HTML response

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`