### PR TITLE
Add account settings page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -121,3 +121,10 @@ def nashville_forecast(
     return templates.TemplateResponse(
         "forecast.html", {"request": request, "forecast": forecast}
     )
+
+
+@app.get("/account", response_class=HTMLResponse)
+def account_page(request: Request, user: models.User = Depends(get_current_user)):
+    return templates.TemplateResponse(
+        "account.html", {"request": request, "username": user.username}
+    )

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Success</title>
+    <title>Account Settings</title>
     <style>
       :root {
         --bg-color: #f5f5f5;
@@ -25,7 +25,7 @@
         height: 100vh;
         margin: 0;
       }
-      .success-container {
+      .account-container {
         background: var(--container-bg);
         padding: 2rem;
         border-radius: 8px;
@@ -38,16 +38,11 @@
     </style>
   </head>
   <body>
-    <div class="success-container">
-      <h1>Congrats! You signed in!</h1>
-      <p>Welcome {{ username }}!</p>
-      <img id="cat-photo" src="{{ cat_url }}" alt="Random Cat" />
+    <div class="account-container">
+      <h1>Account Settings</h1>
+      <p>Username: {{ username }}</p>
       <button id="toggle-dark" type="button">Toggle Dark Mode</button>
-      <p>
-        <a href="/forecast/nashville">Nashville Forecast</a>
-      </p>
-      <p><a href="/account">Account Settings</a></p>
-      <a href="/logout">Logout</a>
+      <p><a href="/protected">Back</a></p>
     </div>
     <script>
       function applyDarkMode(on) {

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,0 +1,33 @@
+def login_helper(client, username, password):
+    client.post(
+        "/signup",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    response = client.post(
+        "/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    client.cookies.update(response.cookies)
+
+
+def test_account_requires_login(client):
+    response = client.get("/account")
+    assert response.status_code == 401
+
+
+def test_account_page_and_link(client):
+    username = "settings"
+    password = "secret"
+    login_helper(client, username, password)
+
+    response = client.get("/protected")
+    assert response.status_code == 200
+    assert '<a href="/account">' in response.text
+
+    response = client.get("/account")
+    assert response.status_code == 200
+    assert "Account Settings" in response.text
+    assert username in response.text


### PR DESCRIPTION
## Summary
- add `/account` endpoint to view account settings
- link to account settings from the protected page
- add new account settings template
- test access and link to the account page

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`