### PR TITLE
Add navigation sidebar

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -59,3 +59,8 @@ th, td {
 a {
     color: var(--link-color);
 }
+
+.sidebar {
+    margin-right: 2rem;
+    text-align: left;
+}

--- a/templates/account.html
+++ b/templates/account.html
@@ -5,11 +5,11 @@
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
+    {% include "sidebar.html" %}
     <div class="account-container">
       <h1>Account Settings</h1>
       <p>Username: {{ username }}</p>
       <button id="toggle-dark" type="button">Toggle Dark Mode</button>
-      <p><a href="/protected">Back</a></p>
     </div>
     <script>
       function applyDarkMode(on) {

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
+    {% include "sidebar.html" %}
     <div class="forecast-container">
       <h1>Nashville 7-Day Forecast</h1>
       <button id="toggle-dark" type="button">Toggle Dark Mode</button>
@@ -18,7 +19,6 @@
           {% endfor %}
         </tbody>
       </table>
-      <p><a href="/">Back to Login</a></p>
     </div>
     <script>
       function applyDarkMode(on) {

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,0 +1,6 @@
+<div class="sidebar">
+  <p><a href="/protected">Home</a></p>
+  <p><a href="/forecast/nashville">Nashville Forecast</a></p>
+  <p><a href="/account">Account Settings</a></p>
+  <a href="/logout">Logout</a>
+</div>

--- a/templates/success.html
+++ b/templates/success.html
@@ -5,16 +5,12 @@
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
+    {% include "sidebar.html" %}
     <div class="success-container">
       <h1>Congrats! You signed in!</h1>
       <p>Welcome {{ username }}!</p>
       <img id="cat-photo" src="{{ cat_url }}" alt="Random Cat" />
       <button id="toggle-dark" type="button">Toggle Dark Mode</button>
-      <p>
-        <a href="/forecast/nashville">Nashville Forecast</a>
-      </p>
-      <p><a href="/account">Account Settings</a></p>
-      <a href="/logout">Logout</a>
     </div>
     <script>
       function applyDarkMode(on) {

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -31,3 +31,4 @@ def test_account_page_and_link(client):
     assert response.status_code == 200
     assert "Account Settings" in response.text
     assert username in response.text
+    assert '<div class="sidebar">' in response.text

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -25,6 +25,7 @@ def test_signup_and_login(client):
     response = client.get("/protected")
     assert response.status_code == 200
     assert "Congrats! You signed in!" in response.text
+    assert '<div class="sidebar">' in response.text
     assert '<a href="/forecast/nashville">' in response.text
 
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -49,6 +49,7 @@ def test_nashville_forecast_endpoint(monkeypatch, client):
     assert response.status_code == 200
     assert "Nashville 7-Day Forecast" in response.text
     assert expected["daily"]["time"][0] in response.text
+    assert '<div class="sidebar">' in response.text
 
 
 def test_nashville_forecast_requires_login(monkeypatch, client):


### PR DESCRIPTION
## Summary
- create a reusable sidebar for authenticated users
- include the sidebar on the success, forecast, and account pages
- add basic sidebar styling
- verify sidebar appears via tests

## Testing
- `python -m pytest -q`