### PR TITLE
Move dark mode toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a small FastAPI application with user authentication.
 - SQLite database for storing users by default
 - Optional PostgreSQL support via the `DATABASE_URL` environment variable
 - Protected page that greets authenticated users
-- Optional dark mode toggle on all pages
+- Dark mode toggle available from the account settings page
 
 ## Development
 Run the setup script to create a virtual environment and install dependencies:

--- a/templates/account.html
+++ b/templates/account.html
@@ -23,10 +23,13 @@
       const dark = localStorage.getItem('darkMode') === 'true';
       applyDarkMode(dark);
 
-      document.getElementById('toggle-dark').addEventListener('click', () => {
-        const enabled = document.body.classList.toggle('dark-mode');
-        localStorage.setItem('darkMode', enabled);
-      });
+      const toggle = document.getElementById('toggle-dark');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const enabled = document.body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', enabled);
+        });
+      }
     </script>
   </body>
 </html>

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -8,7 +8,6 @@
     {% include "sidebar.html" %}
     <div class="forecast-container">
       <h1>Nashville 7-Day Forecast</h1>
-      <button id="toggle-dark" type="button">Toggle Dark Mode</button>
       <table>
         <thead>
           <tr><th>Date</th><th>High</th><th>Low</th></tr>
@@ -32,10 +31,13 @@
       const dark = localStorage.getItem('darkMode') === 'true';
       applyDarkMode(dark);
 
-      document.getElementById('toggle-dark').addEventListener('click', () => {
-        const enabled = document.body.classList.toggle('dark-mode');
-        localStorage.setItem('darkMode', enabled);
-      });
+      const toggle = document.getElementById('toggle-dark');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const enabled = document.body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', enabled);
+        });
+      }
     </script>
   </body>
 </html>

--- a/templates/login.html
+++ b/templates/login.html
@@ -7,7 +7,6 @@
   <body>
     <div class="login-container">
       <h1>Login</h1>
-      <button id="toggle-dark" type="button">Toggle Dark Mode</button>
       {% if error %}
       <p style="color: red">{{ error }}</p>
       {% endif %}
@@ -38,10 +37,13 @@
       const dark = localStorage.getItem('darkMode') === 'true';
       applyDarkMode(dark);
 
-      document.getElementById('toggle-dark').addEventListener('click', () => {
-        const enabled = document.body.classList.toggle('dark-mode');
-        localStorage.setItem('darkMode', enabled);
-      });
+      const toggle = document.getElementById('toggle-dark');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const enabled = document.body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', enabled);
+        });
+      }
     </script>
   </body>
 </html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -7,7 +7,6 @@
   <body>
     <div class="signup-container">
       <h1>Sign Up</h1>
-      <button id="toggle-dark" type="button">Toggle Dark Mode</button>
       <form action="/signup" method="post">
         <label>
           Username:
@@ -35,10 +34,13 @@
       const dark = localStorage.getItem('darkMode') === 'true';
       applyDarkMode(dark);
 
-      document.getElementById('toggle-dark').addEventListener('click', () => {
-        const enabled = document.body.classList.toggle('dark-mode');
-        localStorage.setItem('darkMode', enabled);
-      });
+      const toggle = document.getElementById('toggle-dark');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const enabled = document.body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', enabled);
+        });
+      }
     </script>
   </body>
 </html>

--- a/templates/success.html
+++ b/templates/success.html
@@ -10,7 +10,6 @@
       <h1>Congrats! You signed in!</h1>
       <p>Welcome {{ username }}!</p>
       <img id="cat-photo" src="{{ cat_url }}" alt="Random Cat" />
-      <button id="toggle-dark" type="button">Toggle Dark Mode</button>
     </div>
     <script>
       function applyDarkMode(on) {
@@ -24,10 +23,13 @@
       const dark = localStorage.getItem('darkMode') === 'true';
       applyDarkMode(dark);
 
-      document.getElementById('toggle-dark').addEventListener('click', () => {
-        const enabled = document.body.classList.toggle('dark-mode');
-        localStorage.setItem('darkMode', enabled);
-      });
+      const toggle = document.getElementById('toggle-dark');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const enabled = document.body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', enabled);
+        });
+      }
     </script>
   </body>
 </html>

--- a/tests/test_darkmode.py
+++ b/tests/test_darkmode.py
@@ -1,19 +1,19 @@
-def test_darkmode_toggle_in_login_page(client):
+def test_darkmode_toggle_not_in_login_page(client):
     response = client.get("/login")
     assert response.status_code == 200
-    assert 'id="toggle-dark"' in response.text
+    assert 'id="toggle-dark"' not in response.text
     assert 'applyDarkMode' in response.text
     assert "localStorage.getItem('darkMode')" in response.text
 
 
-def test_darkmode_toggle_in_signup_page(client):
+def test_darkmode_toggle_not_in_signup_page(client):
     response = client.get("/signup")
     assert response.status_code == 200
-    assert 'id="toggle-dark"' in response.text
+    assert 'id="toggle-dark"' not in response.text
     assert 'applyDarkMode' in response.text
 
 
-def test_darkmode_toggle_in_protected_page_after_login(client):
+def test_darkmode_toggle_in_account_page_after_login(client):
     username = "darktoggle"
     password = "secret"
 
@@ -32,7 +32,7 @@ def test_darkmode_toggle_in_protected_page_after_login(client):
     assert response.status_code == 303
     client.cookies.update(response.cookies)
 
-    response = client.get("/protected")
+    response = client.get("/account")
     assert response.status_code == 200
     assert 'id="toggle-dark"' in response.text
     assert 'applyDarkMode' in response.text


### PR DESCRIPTION
## Summary
- keep dark mode scripts on every page but toggle only from account page
- update templates to remove toggle button everywhere except the account page
- adjust README to note new location of dark mode toggle
- update tests for the new behaviour

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`