### PR TITLE
Add header to signed-in pages

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -15,10 +15,37 @@ body {
     background-color: var(--bg-color);
     color: var(--text-color);
     display: flex;
+    flex-direction: column;
     justify-content: center;
     align-items: center;
-    height: 100vh;
+    min-height: 100vh;
     margin: 0;
+}
+
+.page-body {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    width: 100%;
+    flex: 1;
+}
+
+.top-header {
+    width: 100%;
+    background: var(--container-bg);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+.top-header .title {
+    font-weight: bold;
+    font-size: 1.25rem;
+}
+.top-header a {
+    color: var(--link-color);
+    text-decoration: none;
 }
 .login-container,
 .signup-container,

--- a/templates/account.html
+++ b/templates/account.html
@@ -5,11 +5,14 @@
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
-    {% include "sidebar.html" %}
-    <div class="account-container">
-      <h1>Account Settings</h1>
-      <p>Username: {{ username }}</p>
-      <button id="toggle-dark" type="button">Toggle Dark Mode</button>
+    {% include "header.html" %}
+    <div class="page-body">
+      {% include "sidebar.html" %}
+      <div class="account-container">
+        <h1>Account Settings</h1>
+        <p>Username: {{ username }}</p>
+        <button id="toggle-dark" type="button">Toggle Dark Mode</button>
+      </div>
     </div>
     <script>
       function applyDarkMode(on) {

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -5,12 +5,14 @@
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
-    {% include "sidebar.html" %}
-    <div class="forecast-container">
-      <h1>Nashville 7-Day Forecast</h1>
-      <table>
-        <thead>
-          <tr><th>Date</th><th>High</th><th>Low</th></tr>
+    {% include "header.html" %}
+    <div class="page-body">
+      {% include "sidebar.html" %}
+      <div class="forecast-container">
+        <h1>Nashville 7-Day Forecast</h1>
+        <table>
+          <thead>
+            <tr><th>Date</th><th>High</th><th>Low</th></tr>
         </thead>
         <tbody>
           {% for date, high, low in forecast %}
@@ -18,6 +20,7 @@
           {% endfor %}
         </tbody>
       </table>
+      </div>
     </div>
     <script>
       function applyDarkMode(on) {

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,0 +1,4 @@
+<div class="top-header">
+  <div class="title">Codex Playground</div>
+  <a href="/logout">Logout</a>
+</div>

--- a/templates/success.html
+++ b/templates/success.html
@@ -5,11 +5,14 @@
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>
-    {% include "sidebar.html" %}
-    <div class="success-container">
-      <h1>Congrats! You signed in!</h1>
-      <p>Welcome {{ username }}!</p>
-      <img id="cat-photo" src="{{ cat_url }}" alt="Random Cat" />
+    {% include "header.html" %}
+    <div class="page-body">
+      {% include "sidebar.html" %}
+      <div class="success-container">
+        <h1>Congrats! You signed in!</h1>
+        <p>Welcome {{ username }}!</p>
+        <img id="cat-photo" src="{{ cat_url }}" alt="Random Cat" />
+      </div>
     </div>
     <script>
       function applyDarkMode(on) {

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -29,6 +29,8 @@ def test_account_page_and_link(client):
 
     response = client.get("/account")
     assert response.status_code == 200
+    assert '<div class="top-header">' in response.text
+    assert 'Codex Playground' in response.text
     assert "Account Settings" in response.text
     assert username in response.text
     assert '<div class="sidebar">' in response.text

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -25,6 +25,8 @@ def test_signup_and_login(client):
     response = client.get("/protected")
     assert response.status_code == 200
     assert "Congrats! You signed in!" in response.text
+    assert '<div class="top-header">' in response.text
+    assert 'Codex Playground' in response.text
     assert '<div class="sidebar">' in response.text
     assert '<a href="/forecast/nashville">' in response.text
 

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -49,6 +49,8 @@ def test_nashville_forecast_endpoint(monkeypatch, client):
     assert response.status_code == 200
     assert "Nashville 7-Day Forecast" in response.text
     assert expected["daily"]["time"][0] in response.text
+    assert '<div class="top-header">' in response.text
+    assert 'Codex Playground' in response.text
     assert '<div class="sidebar">' in response.text
 
 


### PR DESCRIPTION
## Summary
- create reusable header partial with site title and logout link
- include header on success, forecast and account pages
- adjust layout styles for new header
- test for header on all signed in pages

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`