### PR TITLE
Normalize cat photo sizing

### DIFF
--- a/templates/success.html
+++ b/templates/success.html
@@ -9,7 +9,14 @@
     <div class="success-container">
       <h1>Congrats! You signed in!</h1>
       <p>Welcome {{ username }}!</p>
-      <img id="cat-photo" src="{{ cat_url }}" alt="Random Cat" />
+      <img
+        id="cat-photo"
+        src="{{ cat_url }}"
+        alt="Random Cat"
+        width="300"
+        height="300"
+        style="object-fit: cover;"
+      />
     </div>
     <script>
       function applyDarkMode(on) {

--- a/tests/test_cat_photo.py
+++ b/tests/test_cat_photo.py
@@ -22,6 +22,11 @@ def test_cat_photo_display_after_login(client):
     response = client.get("/protected")
     assert response.status_code == 200
     assert 'id="cat-photo"' in response.text
-    match = re.search(r'<img[^>]+id="cat-photo"[^>]+src="([^"]+)"', response.text)
-    assert match, "cat photo img tag with src not found"
-    assert match.group(1).startswith("https://cataas.com/cat?")
+    match = re.search(r'<img[^>]*id="cat-photo"[^>]*>', response.text)
+    assert match, "cat photo img tag not found"
+    tag = match.group(0)
+    src_match = re.search(r'src="([^"]+)"', tag)
+    assert src_match, "src attribute not found"
+    assert src_match.group(1).startswith("https://cataas.com/cat?")
+    assert 'width="300"' in tag
+    assert 'height="300"' in tag


### PR DESCRIPTION
## Summary
- fix `<img id="cat-photo">` so all cat pictures render at the same size
- test that the cat photo img tag includes width and height attributes

## Testing
- `venv/bin/python -m pytest -q`