### PR TITLE
Fix header width overflow

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -33,6 +33,7 @@ body {
 
 .top-header {
     width: 100%;
+    box-sizing: border-box;
     background: var(--container-bg);
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
## Summary
- ensure the top header uses border-box sizing so padding doesn't force horizontal scroll

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`