### PR TITLE
Add random dog photo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains a small FastAPI application with user authentication.
 - Optional PostgreSQL support via the `DATABASE_URL` environment variable
 - Protected page that greets authenticated users
 - Dark mode toggle available from the account settings page
+- Random dog photo page for logged in users
 
 ## Development
 Run the setup script to create a virtual environment and install dependencies:

--- a/app/main.py
+++ b/app/main.py
@@ -136,6 +136,19 @@ def nashville_forecast(
     )
 
 
+@app.get("/dogs", response_class=HTMLResponse)
+def random_dog(
+    request: Request, user: models.User = Depends(get_current_user)
+):
+    """Display a random dog photo."""
+    dog_url = f"https://placedog.net/500?{int(time.time())}"
+    return templates.TemplateResponse(
+        request,
+        "dog.html",
+        {"dog_url": dog_url},
+    )
+
+
 @app.get("/account", response_class=HTMLResponse)
 def account_page(request: Request, user: models.User = Depends(get_current_user)):
     return templates.TemplateResponse(

--- a/templates/dog.html
+++ b/templates/dog.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Random Dog</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    {% include "header.html" %}
+    <div class="page-body">
+      {% include "sidebar.html" %}
+      <div class="success-container">
+        <h1>Random Dog Photo</h1>
+        <div id="spinner" class="spinner"></div>
+        <img
+            id="dog-photo"
+            src="{{ dog_url }}"
+            alt="Random Dog"
+            width="300"
+            height="300"
+            style="object-fit: cover; display: none;"
+        />
+      </div>
+    </div>
+    <script>
+      function applyDarkMode(on) {
+        if (on) {
+          document.body.classList.add('dark-mode');
+        } else {
+          document.body.classList.remove('dark-mode');
+        }
+      }
+
+      const dark = localStorage.getItem('darkMode') === 'true';
+      applyDarkMode(dark);
+
+      const toggle = document.getElementById('toggle-dark');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const enabled = document.body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', enabled);
+        });
+      }
+
+      const img = document.getElementById('dog-photo');
+      const spinner = document.getElementById('spinner');
+      if (img && spinner) {
+        spinner.style.display = 'block';
+        img.addEventListener('load', () => {
+          spinner.style.display = 'none';
+          img.style.display = 'block';
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,5 +1,6 @@
 <div class="sidebar">
   <p><a href="/protected">Home</a></p>
   <p><a href="/forecast/nashville">Nashville Forecast</a></p>
+  <p><a href="/dogs">Random Dog</a></p>
   <p><a href="/account">Account Settings</a></p>
 </div>

--- a/tests/test_dog_photo.py
+++ b/tests/test_dog_photo.py
@@ -1,0 +1,33 @@
+import re
+
+
+def test_dog_photo_display_after_login(client):
+    username = "doguser"
+    password = "secret"
+
+    client.post(
+        "/signup",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+
+    response = client.post(
+        "/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    client.cookies.update(response.cookies)
+
+    response = client.get("/dogs")
+    assert response.status_code == 200
+    assert 'id="dog-photo"' in response.text
+    assert 'id="spinner"' in response.text
+    match = re.search(r'<img[^>]*id="dog-photo"[^>]*>', response.text)
+    assert match, "dog photo img tag not found"
+    tag = match.group(0)
+    src_match = re.search(r'src="([^"]+)"', tag)
+    assert src_match, "src attribute not found"
+    assert src_match.group(1).startswith("https://")
+    assert 'width="300"' in tag
+    assert 'height="300"' in tag


### PR DESCRIPTION
## Summary
- provide new `/dogs` route to display a random dog photo
- show link in sidebar
- add dog page template
- document feature in README
- test dog photo page

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`