### PR TITLE
Add detailed weather forecast feature

### DIFF
--- a/templates/forecast_detailed.html
+++ b/templates/forecast_detailed.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Nashville Detailed Forecast</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    {% include "header.html" %}
+    <div class="page-body">
+      {% include "sidebar.html" %}
+      <div class="forecast-container">
+        <h1>Nashville Detailed 7-Day Forecast</h1>
+        <table>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>High</th>
+              <th>Low</th>
+              <th>Rain %</th>
+              <th>Code</th>
+            </tr>
+        </thead>
+        <tbody>
+          {% for day in forecast %}
+          <tr>
+            <td>{{ day.date }}</td>
+            <td>{{ day.high }}&deg;F</td>
+            <td>{{ day.low }}&deg;F</td>
+            <td>{{ day.rain }}%</td>
+            <td>{{ day.code }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      </div>
+    </div>
+    <script>
+      function applyDarkMode(on) {
+        if (on) {
+          document.body.classList.add('dark-mode');
+        } else {
+          document.body.classList.remove('dark-mode');
+        }
+      }
+
+      const dark = localStorage.getItem('darkMode') === 'true';
+      applyDarkMode(dark);
+
+      const toggle = document.getElementById('toggle-dark');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const enabled = document.body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', enabled);
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,5 +1,6 @@
 <div class="sidebar">
   <p><a href="/protected">Home</a></p>
   <p><a href="/forecast/nashville">Nashville Forecast</a></p>
+  <p><a href="/forecast/nashville/detailed">Detailed Forecast</a></p>
   <p><a href="/account">Account Settings</a></p>
 </div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,6 +29,7 @@ def test_signup_and_login(client):
     assert 'Codex Playground' in response.text
     assert '<div class="sidebar">' in response.text
     assert '<a href="/forecast/nashville">' in response.text
+    assert '<a href="/forecast/nashville/detailed">' in response.text
 
 
 def test_signup_success(client):

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -66,3 +66,60 @@ def test_nashville_forecast_requires_login(monkeypatch, client):
     assert response.status_code == 303
     assert response.headers["location"].startswith("/login")
     assert "error=Please%20log%20in%20to%20access%20that%20page" in response.headers["location"]
+
+
+def test_detailed_forecast_endpoint(monkeypatch, client):
+    expected = {
+        "daily": {
+            "time": ["2025-05-20", "2025-05-21", "2025-05-22", "2025-05-23", "2025-05-24", "2025-05-25", "2025-05-26"],
+            "temperature_2m_max": [70, 71, 72, 73, 74, 75, 76],
+            "temperature_2m_min": [50, 51, 52, 53, 54, 55, 56],
+            "precipitation_probability_max": [10, 20, 30, 40, 50, 60, 70],
+            "weathercode": [0, 1, 2, 3, 45, 48, 51],
+        }
+    }
+
+    class MockResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+        def raise_for_status(self):
+            pass
+
+    def mock_get(url, params=None, timeout=None):
+        assert url == "https://api.open-meteo.com/v1/forecast"
+        assert (
+            params["daily"]
+            == "temperature_2m_max,temperature_2m_min,precipitation_probability_max,weathercode"
+        )
+        return MockResponse(expected)
+
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    username = "detailed"
+    password = "secret"
+    client.post("/signup", data={"username": username, "password": password}, follow_redirects=False)
+    response = client.post("/login", data={"username": username, "password": password}, follow_redirects=False)
+    assert response.status_code == 303
+    client.cookies.update(response.cookies)
+
+    response = client.get("/forecast/nashville/detailed")
+    assert response.status_code == 200
+    assert "Nashville Detailed 7-Day Forecast" in response.text
+    assert str(expected["daily"]["precipitation_probability_max"][0]) in response.text
+    assert str(expected["daily"]["weathercode"][0]) in response.text
+
+
+def test_detailed_forecast_requires_login(monkeypatch, client):
+    def fail_get(*args, **kwargs):
+        raise AssertionError("httpx.get should not be called when unauthorized")
+
+    monkeypatch.setattr(httpx, "get", fail_get)
+
+    response = client.get("/forecast/nashville/detailed", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/login")
+    assert "error=Please%20log%20in%20to%20access%20that%20page" in response.headers["location"]


### PR DESCRIPTION
## Summary
- extend weather forecast endpoint to offer a detailed version
- show detailed forecast link in sidebar
- add HTML template for detailed forecast table
- test the new endpoint and link

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`