### PR TITLE
Add detailed Nashville forecast

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a small FastAPI application with user authentication.
 - Protected page that greets authenticated users
 - Dark mode toggle available from the account settings page
 - Random dog photo page for logged in users
+- Nashville weather forecast including a detailed view
 
 ## Development
 Run the setup script to create a virtual environment and install dependencies:

--- a/app/main.py
+++ b/app/main.py
@@ -136,6 +136,62 @@ def nashville_forecast(
     )
 
 
+@app.get("/forecast/nashville/detailed", response_class=HTMLResponse)
+def nashville_detailed_forecast(
+    request: Request, user: models.User = Depends(get_current_user)
+):
+    """Return Nashville's 7 day detailed weather forecast as a web page."""
+    response = httpx.get(
+        "https://api.open-meteo.com/v1/forecast",
+        params={
+            "latitude": 36.1627,
+            "longitude": -86.7816,
+            "daily": "weathercode,temperature_2m_max,temperature_2m_min,precipitation_probability_max",
+            "forecast_days": 7,
+            "temperature_unit": "fahrenheit",
+            "timezone": "America/Chicago",
+        },
+        timeout=10,
+    )
+    response.raise_for_status()
+    data = response.json()
+    weather_map = {
+        0: "Clear",
+        1: "Mainly clear",
+        2: "Partly cloudy",
+        3: "Overcast",
+        45: "Fog",
+        48: "Rime fog",
+        51: "Light drizzle",
+        53: "Drizzle",
+        55: "Heavy drizzle",
+        61: "Light rain",
+        63: "Rain",
+        65: "Heavy rain",
+        80: "Rain showers",
+        95: "Thunderstorm",
+    }
+    forecast = [
+        (
+            date,
+            weather_map.get(code, "Unknown"),
+            tmax,
+            tmin,
+            precip,
+        )
+        for date, code, tmax, tmin, precip in zip(
+            data["daily"]["time"],
+            data["daily"]["weathercode"],
+            data["daily"]["temperature_2m_max"],
+            data["daily"]["temperature_2m_min"],
+            data["daily"]["precipitation_probability_max"],
+        )
+    ]
+    return templates.TemplateResponse(
+        "forecast_detail.html", {"request": request, "forecast": forecast}
+    )
+
+
 @app.get("/dogs", response_class=HTMLResponse)
 def random_dog(
     request: Request, user: models.User = Depends(get_current_user)

--- a/templates/forecast_detail.html
+++ b/templates/forecast_detail.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Nashville Detailed Forecast</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    {% include "header.html" %}
+    <div class="page-body">
+      {% include "sidebar.html" %}
+      <div class="forecast-container">
+        <h1>Nashville Detailed Forecast</h1>
+        <table>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Conditions</th>
+              <th>High</th>
+              <th>Low</th>
+              <th>Precip</th>
+            </tr>
+        </thead>
+        <tbody>
+          {% for date, condition, high, low, precip in forecast %}
+          <tr>
+            <td>{{ date }}</td>
+            <td>{{ condition }}</td>
+            <td>{{ high }}&deg;F</td>
+            <td>{{ low }}&deg;F</td>
+            <td>{{ precip }}%</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      </div>
+    </div>
+    <script>
+      function applyDarkMode(on) {
+        if (on) {
+          document.body.classList.add('dark-mode');
+        } else {
+          document.body.classList.remove('dark-mode');
+        }
+      }
+
+      const dark = localStorage.getItem('darkMode') === 'true';
+      applyDarkMode(dark);
+
+      const toggle = document.getElementById('toggle-dark');
+      if (toggle) {
+        toggle.addEventListener('click', () => {
+          const enabled = document.body.classList.toggle('dark-mode');
+          localStorage.setItem('darkMode', enabled);
+        });
+      }
+    </script>
+  </body>
+</html>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,6 +1,7 @@
 <div class="sidebar">
   <p><a href="/protected">Home</a></p>
   <p><a href="/forecast/nashville">Nashville Forecast</a></p>
+  <p><a href="/forecast/nashville/detailed">Detailed Forecast</a></p>
   <p><a href="/dogs">Random Dog</a></p>
   <p><a href="/account">Account Settings</a></p>
 </div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,6 +29,7 @@ def test_signup_and_login(client):
     assert 'Codex Playground' in response.text
     assert '<div class="sidebar">' in response.text
     assert '<a href="/forecast/nashville">' in response.text
+    assert '<a href="/forecast/nashville/detailed">' in response.text
 
 
 def test_signup_success(client):


### PR DESCRIPTION
## Summary
- add a new `/forecast/nashville/detailed` endpoint
- show condition descriptions, precip chances, and highs/lows
- include a new template and sidebar link
- update tests and README

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`