### PR TITLE
Add detailed forecast toggle

### DIFF
--- a/templates/account.html
+++ b/templates/account.html
@@ -8,11 +8,12 @@
     {% include "header.html" %}
     <div class="page-body">
       {% include "sidebar.html" %}
-      <div class="account-container">
-        <h1>Account Settings</h1>
-        <p>Username: {{ username }}</p>
-        <button id="toggle-dark" type="button">Toggle Dark Mode</button>
-      </div>
+        <div class="account-container">
+          <h1>Account Settings</h1>
+          <p>Username: {{ username }}</p>
+          <button id="toggle-dark" type="button">Toggle Dark Mode</button>
+          <button id="toggle-detailed" type="button">Enable Detailed Forecast</button>
+        </div>
     </div>
     <script>
       function applyDarkMode(on) {
@@ -31,6 +32,24 @@
         toggle.addEventListener('click', () => {
           const enabled = document.body.classList.toggle('dark-mode');
           localStorage.setItem('darkMode', enabled);
+        });
+      }
+
+      function updateDetailedButton() {
+        const enabled = localStorage.getItem('detailedForecast') === 'true';
+        const button = document.getElementById('toggle-detailed');
+        if (button) {
+          button.textContent = enabled ? 'Disable Detailed Forecast' : 'Enable Detailed Forecast';
+        }
+      }
+
+      updateDetailedButton();
+      const detailedToggle = document.getElementById('toggle-detailed');
+      if (detailedToggle) {
+        detailedToggle.addEventListener('click', () => {
+          const enabled = localStorage.getItem('detailedForecast') === 'true';
+          localStorage.setItem('detailedForecast', !enabled);
+          updateDetailedButton();
         });
       }
     </script>

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -34,6 +34,10 @@
       const dark = localStorage.getItem('darkMode') === 'true';
       applyDarkMode(dark);
 
+      if (localStorage.getItem('detailedForecast') === 'true') {
+        window.location.replace('/forecast/nashville/detailed');
+      }
+
       const toggle = document.getElementById('toggle-dark');
       if (toggle) {
         toggle.addEventListener('click', () => {

--- a/templates/forecast_detail.html
+++ b/templates/forecast_detail.html
@@ -46,6 +46,10 @@
       const dark = localStorage.getItem('darkMode') === 'true';
       applyDarkMode(dark);
 
+      if (localStorage.getItem('detailedForecast') !== 'true') {
+        window.location.replace('/forecast/nashville');
+      }
+
       const toggle = document.getElementById('toggle-dark');
       if (toggle) {
         toggle.addEventListener('click', () => {

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -36,3 +36,4 @@ def test_account_page_and_link(client):
     assert "Account Settings" in response.text
     assert username in response.text
     assert '<div class="sidebar">' in response.text
+    assert 'id="toggle-detailed"' in response.text

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -52,6 +52,7 @@ def test_nashville_forecast_endpoint(monkeypatch, client):
     assert '<div class="top-header">' in response.text
     assert 'Codex Playground' in response.text
     assert '<div class="sidebar">' in response.text
+    assert "detailedForecast" in response.text
 
 
 def test_nashville_forecast_requires_login(monkeypatch, client):
@@ -118,6 +119,7 @@ def test_nashville_detailed_forecast_endpoint(monkeypatch, client):
     assert expected["daily"]["time"][0] in response.text
     assert "Partly cloudy" in response.text
     assert "30%" in response.text
+    assert "detailedForecast" in response.text
 
 
 def test_nashville_detailed_forecast_requires_login(monkeypatch, client):


### PR DESCRIPTION
## Summary
- allow users to toggle detailed forecast view from the account page
- redirect forecast pages based on stored `detailedForecast` preference
- test that the account page contains the new toggle
- test that forecast pages include the new JS

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`