### PR TITLE
Remove redundant sidebar link

### DIFF
--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,7 +1,6 @@
 <div class="sidebar">
   <p><a href="/protected">Home</a></p>
   <p><a href="/forecast/nashville">Nashville Forecast</a></p>
-  <p><a href="/forecast/nashville/detailed">Detailed Forecast</a></p>
   <p><a href="/dogs">Random Dog</a></p>
   <p><a href="/account">Account Settings</a></p>
 </div>

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -29,9 +29,6 @@ def test_signup_and_login(client):
     assert 'Codex Playground' in response.text
     assert '<div class="sidebar">' in response.text
     assert '<a href="/forecast/nashville">' in response.text
-    assert '<a href="/forecast/nashville/detailed">' in response.text
-
-
 def test_signup_success(client):
     response = client.post(
         "/signup",


### PR DESCRIPTION
## Summary
- remove link to the detailed forecast page from the sidebar template
- update auth test to stop expecting that link

## Testing
- `PYTHONPATH=. venv/bin/pytest -q`