### PR TITLE
Improve account settings toggles

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -132,3 +132,56 @@ a {
     0% { transform: rotate(0deg); }
     100% { transform: rotate(360deg); }
 }
+
+/* Toggle switch styles */
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 42px;
+    height: 24px;
+    margin-right: 0.5rem;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: .4s;
+    border-radius: 24px;
+}
+
+.slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: white;
+    transition: .4s;
+    border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+    background-color: #007bff;
+}
+
+.switch input:checked + .slider:before {
+    transform: translateX(18px);
+}
+
+.toggle-row {
+    display: flex;
+    align-items: center;
+    margin-top: 1rem;
+}

--- a/templates/account.html
+++ b/templates/account.html
@@ -11,8 +11,20 @@
         <div class="account-container">
           <h1>Account Settings</h1>
           <p>Username: {{ username }}</p>
-          <button id="toggle-dark" type="button">Toggle Dark Mode</button>
-          <button id="toggle-detailed" type="button">Enable Detailed Forecast</button>
+          <div class="toggle-row">
+            <label class="switch">
+              <input type="checkbox" id="toggle-dark" />
+              <span class="slider round"></span>
+            </label>
+            <span>Dark Mode</span>
+          </div>
+          <div class="toggle-row">
+            <label class="switch">
+              <input type="checkbox" id="toggle-detailed" />
+              <span class="slider round"></span>
+            </label>
+            <span>Detailed Forecast</span>
+          </div>
         </div>
     </div>
     <script>
@@ -29,27 +41,28 @@
 
       const toggle = document.getElementById('toggle-dark');
       if (toggle) {
-        toggle.addEventListener('click', () => {
-          const enabled = document.body.classList.toggle('dark-mode');
+        toggle.checked = dark;
+        toggle.addEventListener('change', () => {
+          const enabled = toggle.checked;
+          applyDarkMode(enabled);
           localStorage.setItem('darkMode', enabled);
         });
       }
 
-      function updateDetailedButton() {
+      function applyDetailedState() {
         const enabled = localStorage.getItem('detailedForecast') === 'true';
-        const button = document.getElementById('toggle-detailed');
-        if (button) {
-          button.textContent = enabled ? 'Disable Detailed Forecast' : 'Enable Detailed Forecast';
+        const box = document.getElementById('toggle-detailed');
+        if (box) {
+          box.checked = enabled;
         }
       }
 
-      updateDetailedButton();
+      applyDetailedState();
       const detailedToggle = document.getElementById('toggle-detailed');
       if (detailedToggle) {
-        detailedToggle.addEventListener('click', () => {
-          const enabled = localStorage.getItem('detailedForecast') === 'true';
-          localStorage.setItem('detailedForecast', !enabled);
-          updateDetailedButton();
+        detailedToggle.addEventListener('change', () => {
+          const enabled = detailedToggle.checked;
+          localStorage.setItem('detailedForecast', enabled);
         });
       }
     </script>

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -36,4 +36,4 @@ def test_account_page_and_link(client):
     assert "Account Settings" in response.text
     assert username in response.text
     assert '<div class="sidebar">' in response.text
-    assert 'id="toggle-detailed"' in response.text
+    assert '<input type="checkbox" id="toggle-detailed"' in response.text

--- a/tests/test_darkmode.py
+++ b/tests/test_darkmode.py
@@ -34,5 +34,5 @@ def test_darkmode_toggle_in_account_page_after_login(client):
 
     response = client.get("/account")
     assert response.status_code == 200
-    assert 'id="toggle-dark"' in response.text
+    assert '<input type="checkbox" id="toggle-dark"' in response.text
     assert 'applyDarkMode' in response.text


### PR DESCRIPTION
## Summary
- restyle account page dark mode and detailed forecast toggles
- make toggles checkbox-based in templates and scripts
- add CSS switch styling
- update tests for new toggle markup

## Testing
- `PYTHONPATH=. pytest -q`