### PR TITLE
Update navigation links

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -51,6 +51,10 @@ body {
     font-weight: bold;
     font-size: 1.25rem;
 }
+.top-header .title a {
+    color: inherit;
+    text-decoration: none;
+}
 .top-header a {
     color: var(--link-color);
     text-decoration: none;

--- a/templates/header.html
+++ b/templates/header.html
@@ -1,4 +1,4 @@
 <div class="top-header">
-  <div class="title">Codex Playground</div>
+  <div class="title"><a href="/protected">Codex Playground</a></div>
   <a href="/logout">Logout</a>
 </div>

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,5 +1,4 @@
 <div class="sidebar">
-  <p><a href="/protected">Home</a></p>
   <p><a href="/forecast/nashville">Nashville Forecast</a></p>
   <p><a href="/dogs">Random Dog</a></p>
   <p><a href="/account">Account Settings</a></p>

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -33,7 +33,9 @@ def test_account_page_and_link(client):
     assert response.status_code == 200
     assert '<div class="top-header">' in response.text
     assert 'Codex Playground' in response.text
+    assert '<a href="/protected">Codex Playground</a>' in response.text
     assert "Account Settings" in response.text
     assert username in response.text
     assert '<div class="sidebar">' in response.text
+    assert '<a href="/protected">Home</a>' not in response.text
     assert 'id="toggle-detailed"' in response.text

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -27,7 +27,9 @@ def test_signup_and_login(client):
     assert "Congrats! You signed in!" in response.text
     assert '<div class="top-header">' in response.text
     assert 'Codex Playground' in response.text
+    assert '<a href="/protected">Codex Playground</a>' in response.text
     assert '<div class="sidebar">' in response.text
+    assert '<a href="/protected">Home</a>' not in response.text
     assert '<a href="/forecast/nashville">' in response.text
 def test_signup_success(client):
     response = client.post(

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -51,7 +51,9 @@ def test_nashville_forecast_endpoint(monkeypatch, client):
     assert expected["daily"]["time"][0] in response.text
     assert '<div class="top-header">' in response.text
     assert 'Codex Playground' in response.text
+    assert '<a href="/protected">Codex Playground</a>' in response.text
     assert '<div class="sidebar">' in response.text
+    assert '<a href="/protected">Home</a>' not in response.text
     assert "detailedForecast" in response.text
 
 


### PR DESCRIPTION
## Summary
- link the "Codex Playground" title in the header to the home page
- remove the home link from the sidebar
- keep header title styling the same
- update tests for navigation changes

## Testing
- `source venv/bin/activate`
- `PYTHONPATH=. pytest -q`