### PR TITLE
Fix forecast redirect with detailed toggle

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>{% block title %}{% endblock %}</title>
+    {% block head_scripts %}{% endblock %}
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 {% block title %}Nashville Forecast{% endblock %}
+{% block head_scripts %}
+<script>
+  if (localStorage.getItem('detailedForecast') === 'true') {
+    window.location.replace('/forecast/nashville/detailed');
+  }
+</script>
+{% endblock %}
 {% block content %}
   <div class="forecast-container">
     <h1>Nashville 7-Day Forecast</h1>
@@ -28,9 +35,6 @@
   const dark = localStorage.getItem('darkMode') === 'true';
   applyDarkMode(dark);
 
-  if (localStorage.getItem('detailedForecast') === 'true') {
-    window.location.replace('/forecast/nashville/detailed');
-  }
 
   const toggle = document.getElementById('toggle-dark');
   if (toggle) {

--- a/templates/forecast_detail.html
+++ b/templates/forecast_detail.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 {% block title %}Nashville Detailed Forecast{% endblock %}
+{% block head_scripts %}
+<script>
+  if (localStorage.getItem('detailedForecast') !== 'true') {
+    window.location.replace('/forecast/nashville');
+  }
+</script>
+{% endblock %}
 {% block content %}
   <div class="forecast-container">
     <h1>Nashville Detailed Forecast</h1>
@@ -40,9 +47,6 @@
   const dark = localStorage.getItem('darkMode') === 'true';
   applyDarkMode(dark);
 
-  if (localStorage.getItem('detailedForecast') !== 'true') {
-    window.location.replace('/forecast/nashville');
-  }
 
   const toggle = document.getElementById('toggle-dark');
   if (toggle) {


### PR DESCRIPTION
## Summary
- add a `head_scripts` block in the base template
- move forecast/detailed redirect logic to the new `head_scripts` block to avoid double loading

## Testing
- `source venv/bin/activate`
- `PYTHONPATH=. pytest -q`