### PR TITLE
Refactor login helper in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,3 +45,20 @@ app.dependency_overrides[get_db] = override_get_db
 def client():
     with TestClient(app) as c:
         yield c
+
+
+def login_helper(client, username, password):
+    """Sign up and log in a user, returning the login response."""
+    client.post(
+        "/signup",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    response = client.post(
+        "/login",
+        data={"username": username, "password": password},
+        follow_redirects=False,
+    )
+    assert response.status_code == 303
+    client.cookies.update(response.cookies)
+    return response

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,16 +1,4 @@
-def login_helper(client, username, password):
-    client.post(
-        "/signup",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-    response = client.post(
-        "/login",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
-    client.cookies.update(response.cookies)
+from conftest import login_helper
 
 
 def test_account_requires_login(client):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,27 +1,13 @@
 from app import models, auth
-from conftest import TestingSessionLocal
+from conftest import TestingSessionLocal, login_helper
 
 
 def test_signup_and_login(client):
-    # Sign up
-    response = client.post(
-        "/signup",
-        data={"username": "alice", "password": "secret"},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
-
-    # Login
-    response = client.post(
-        "/login",
-        data={"username": "alice", "password": "secret"},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
+    # Sign up and login
+    response = login_helper(client, "alice", "secret")
     assert response.headers["location"] == "/protected"
 
     # Access protected page using cookies from login
-    client.cookies.update(response.cookies)
     response = client.get("/protected")
     assert response.status_code == 200
     assert "Congrats! You signed in!" in response.text
@@ -47,22 +33,9 @@ def test_signup_success(client):
 
 
 def test_login_success(client):
-    # Create user by signing up first
-    client.post(
-        "/signup",
-        data={"username": "carol", "password": "topsecret"},
-        follow_redirects=False,
-    )
-
-    response = client.post(
-        "/login",
-        data={"username": "carol", "password": "topsecret"},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
+    response = login_helper(client, "carol", "topsecret")
     assert response.headers["location"] == "/protected"
 
-    client.cookies.update(response.cookies)
     response = client.get("/protected")
     assert response.status_code == 200
     assert "Congrats! You signed in!" in response.text

--- a/tests/test_cat_photo.py
+++ b/tests/test_cat_photo.py
@@ -1,23 +1,12 @@
 import re
+from conftest import login_helper
 
 
 def test_cat_photo_display_after_login(client):
     username = "catuser"
     password = "secret"
 
-    client.post(
-        "/signup",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-
-    response = client.post(
-        "/login",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
-    client.cookies.update(response.cookies)
+    login_helper(client, username, password)
 
     response = client.get("/protected")
     assert response.status_code == 200

--- a/tests/test_darkmode.py
+++ b/tests/test_darkmode.py
@@ -1,3 +1,6 @@
+from conftest import login_helper
+
+
 def test_darkmode_toggle_not_in_login_page(client):
     response = client.get("/login")
     assert response.status_code == 200
@@ -17,20 +20,8 @@ def test_darkmode_toggle_in_account_page_after_login(client):
     username = "darktoggle"
     password = "secret"
 
-    # create user if not exists
-    client.post(
-        "/signup",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-
-    response = client.post(
-        "/login",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
-    client.cookies.update(response.cookies)
+    # create user if not exists and log in
+    login_helper(client, username, password)
 
     response = client.get("/account")
     assert response.status_code == 200

--- a/tests/test_dog_photo.py
+++ b/tests/test_dog_photo.py
@@ -1,23 +1,12 @@
 import re
+from conftest import login_helper
 
 
 def test_dog_photo_display_after_login(client):
     username = "doguser"
     password = "secret"
 
-    client.post(
-        "/signup",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-
-    response = client.post(
-        "/login",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
-    client.cookies.update(response.cookies)
+    login_helper(client, username, password)
 
     response = client.get("/dogs")
     assert response.status_code == 200

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -1,4 +1,5 @@
 import httpx
+from conftest import login_helper
 
 
 def test_nashville_forecast_endpoint(monkeypatch, client):
@@ -31,19 +32,7 @@ def test_nashville_forecast_endpoint(monkeypatch, client):
     # create and login user
     username = "weather"
     password = "secret"
-    client.post(
-        "/signup",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-
-    response = client.post(
-        "/login",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
-    client.cookies.update(response.cookies)
+    login_helper(client, username, password)
 
     response = client.get("/forecast/nashville")
     assert response.status_code == 200
@@ -101,19 +90,7 @@ def test_nashville_detailed_forecast_endpoint(monkeypatch, client):
 
     username = "detail"
     password = "secret"
-    client.post(
-        "/signup",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-
-    response = client.post(
-        "/login",
-        data={"username": username, "password": password},
-        follow_redirects=False,
-    )
-    assert response.status_code == 303
-    client.cookies.update(response.cookies)
+    login_helper(client, username, password)
 
     response = client.get("/forecast/nashville/detailed")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- move `login_helper` to `tests/conftest.py`
- use `login_helper` across all tests that perform sign up and login

## Testing
- `source venv/bin/activate`
- `PYTHONPATH=. pytest -q`