### PR TITLE
Refactor darkmode js

### DIFF
--- a/static/darkmode.js
+++ b/static/darkmode.js
@@ -1,0 +1,30 @@
+function applyDarkMode(on) {
+  if (on) {
+    document.body.classList.add('dark-mode');
+  } else {
+    document.body.classList.remove('dark-mode');
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const dark = localStorage.getItem('darkMode') === 'true';
+  applyDarkMode(dark);
+
+  const toggle = document.getElementById('toggle-dark');
+  if (toggle) {
+    if (toggle.type === 'checkbox') {
+      toggle.checked = dark;
+      toggle.addEventListener('change', () => {
+        const enabled = toggle.checked;
+        applyDarkMode(enabled);
+        localStorage.setItem('darkMode', enabled);
+      });
+    } else {
+      toggle.addEventListener('click', () => {
+        const enabled = !document.body.classList.contains('dark-mode');
+        applyDarkMode(enabled);
+        localStorage.setItem('darkMode', enabled);
+      });
+    }
+  }
+});

--- a/templates/account.html
+++ b/templates/account.html
@@ -22,27 +22,6 @@
 {% endblock %}
 {% block scripts %}
 <script>
-  function applyDarkMode(on) {
-    if (on) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
-
-  const dark = localStorage.getItem('darkMode') === 'true';
-  applyDarkMode(dark);
-
-  const toggle = document.getElementById('toggle-dark');
-  if (toggle) {
-    toggle.checked = dark;
-    toggle.addEventListener('change', () => {
-      const enabled = toggle.checked;
-      applyDarkMode(enabled);
-      localStorage.setItem('darkMode', enabled);
-    });
-  }
-
   function applyDetailedState() {
     const enabled = localStorage.getItem('detailedForecast') === 'true';
     const box = document.getElementById('toggle-detailed');

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,7 @@
       {% include "sidebar.html" %}
       {% block content %}{% endblock %}
     </div>
+    <script src="/static/darkmode.js"></script>
     {% block scripts %}{% endblock %}
   </body>
 </html>

--- a/templates/dog.html
+++ b/templates/dog.html
@@ -16,25 +16,6 @@
 {% endblock %}
 {% block scripts %}
 <script>
-  function applyDarkMode(on) {
-    if (on) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
-
-  const dark = localStorage.getItem('darkMode') === 'true';
-  applyDarkMode(dark);
-
-  const toggle = document.getElementById('toggle-dark');
-  if (toggle) {
-    toggle.addEventListener('click', () => {
-      const enabled = document.body.classList.toggle('dark-mode');
-      localStorage.setItem('darkMode', enabled);
-    });
-  }
-
   const img = document.getElementById('dog-photo');
   const spinner = document.getElementById('spinner');
   if (img && spinner) {

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -22,26 +22,4 @@
     </table>
   </div>
 {% endblock %}
-{% block scripts %}
-<script>
-  function applyDarkMode(on) {
-    if (on) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
-
-  const dark = localStorage.getItem('darkMode') === 'true';
-  applyDarkMode(dark);
-
-
-  const toggle = document.getElementById('toggle-dark');
-  if (toggle) {
-    toggle.addEventListener('click', () => {
-      const enabled = document.body.classList.toggle('dark-mode');
-      localStorage.setItem('darkMode', enabled);
-    });
-  }
-</script>
-{% endblock %}
+{% block scripts %}{% endblock %}

--- a/templates/forecast_detail.html
+++ b/templates/forecast_detail.html
@@ -34,26 +34,4 @@
     </table>
   </div>
 {% endblock %}
-{% block scripts %}
-<script>
-  function applyDarkMode(on) {
-    if (on) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
-
-  const dark = localStorage.getItem('darkMode') === 'true';
-  applyDarkMode(dark);
-
-
-  const toggle = document.getElementById('toggle-dark');
-  if (toggle) {
-    toggle.addEventListener('click', () => {
-      const enabled = document.body.classList.toggle('dark-mode');
-      localStorage.setItem('darkMode', enabled);
-    });
-  }
-</script>
-{% endblock %}
+{% block scripts %}{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -25,25 +25,6 @@
       </form>
       <p>Need an account? <a href="/signup">Sign up</a></p>
     </div>
-    <script>
-      function applyDarkMode(on) {
-        if (on) {
-          document.body.classList.add('dark-mode');
-        } else {
-          document.body.classList.remove('dark-mode');
-        }
-      }
-
-      const dark = localStorage.getItem('darkMode') === 'true';
-      applyDarkMode(dark);
-
-      const toggle = document.getElementById('toggle-dark');
-      if (toggle) {
-        toggle.addEventListener('click', () => {
-          const enabled = document.body.classList.toggle('dark-mode');
-          localStorage.setItem('darkMode', enabled);
-        });
-      }
-    </script>
+    <script src="/static/darkmode.js"></script>
   </body>
 </html>

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -22,25 +22,6 @@
       </form>
       <p>Already have an account? <a href="/login">Login</a></p>
     </div>
-    <script>
-      function applyDarkMode(on) {
-        if (on) {
-          document.body.classList.add('dark-mode');
-        } else {
-          document.body.classList.remove('dark-mode');
-        }
-      }
-
-      const dark = localStorage.getItem('darkMode') === 'true';
-      applyDarkMode(dark);
-
-      const toggle = document.getElementById('toggle-dark');
-      if (toggle) {
-        toggle.addEventListener('click', () => {
-          const enabled = document.body.classList.toggle('dark-mode');
-          localStorage.setItem('darkMode', enabled);
-        });
-      }
-    </script>
+    <script src="/static/darkmode.js"></script>
   </body>
 </html>

--- a/templates/success.html
+++ b/templates/success.html
@@ -17,25 +17,6 @@
 {% endblock %}
 {% block scripts %}
 <script>
-  function applyDarkMode(on) {
-    if (on) {
-      document.body.classList.add('dark-mode');
-    } else {
-      document.body.classList.remove('dark-mode');
-    }
-  }
-
-  const dark = localStorage.getItem('darkMode') === 'true';
-  applyDarkMode(dark);
-
-  const toggle = document.getElementById('toggle-dark');
-  if (toggle) {
-    toggle.addEventListener('click', () => {
-      const enabled = document.body.classList.toggle('dark-mode');
-      localStorage.setItem('darkMode', enabled);
-    });
-  }
-
   const img = document.getElementById('cat-photo');
   const spinner = document.getElementById('spinner');
   if (img && spinner) {

--- a/tests/test_darkmode.py
+++ b/tests/test_darkmode.py
@@ -2,15 +2,14 @@ def test_darkmode_toggle_not_in_login_page(client):
     response = client.get("/login")
     assert response.status_code == 200
     assert 'id="toggle-dark"' not in response.text
-    assert 'applyDarkMode' in response.text
-    assert "localStorage.getItem('darkMode')" in response.text
+    assert '<script src="/static/darkmode.js"></script>' in response.text
 
 
 def test_darkmode_toggle_not_in_signup_page(client):
     response = client.get("/signup")
     assert response.status_code == 200
     assert 'id="toggle-dark"' not in response.text
-    assert 'applyDarkMode' in response.text
+    assert '<script src="/static/darkmode.js"></script>' in response.text
 
 
 def test_darkmode_toggle_in_account_page_after_login(client):
@@ -35,4 +34,4 @@ def test_darkmode_toggle_in_account_page_after_login(client):
     response = client.get("/account")
     assert response.status_code == 200
     assert '<input type="checkbox" id="toggle-dark"' in response.text
-    assert 'applyDarkMode' in response.text
+    assert '<script src="/static/darkmode.js"></script>' in response.text


### PR DESCRIPTION
## Summary
- centralize applyDarkMode in `static/darkmode.js`
- load dark mode script from `base.html`
- reference the script in login and signup pages
- drop duplicate script blocks
- update dark mode tests

## Testing
- `source venv/bin/activate`
- `PYTHONPATH=. pytest -q`