### PR TITLE
Handle forecast HTTP errors gracefully

### DIFF
--- a/app/routes/forecast.py
+++ b/app/routes/forecast.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import HTMLResponse
 import httpx
 
@@ -30,19 +30,25 @@ def nashville_forecast(
     request: Request, user: models.User = Depends(get_current_user)
 ):
     """Return Nashville's 7 day weather forecast from Open-Meteo as a web page."""
-    response = httpx.get(
-        "https://api.open-meteo.com/v1/forecast",
-        params={
-            "latitude": 36.1627,
-            "longitude": -86.7816,
-            "daily": "temperature_2m_max,temperature_2m_min",
-            "forecast_days": 7,
-            "temperature_unit": "fahrenheit",
-            "timezone": "America/Chicago",
-        },
-        timeout=10,
-    )
-    response.raise_for_status()
+    try:
+        response = httpx.get(
+            "https://api.open-meteo.com/v1/forecast",
+            params={
+                "latitude": 36.1627,
+                "longitude": -86.7816,
+                "daily": "temperature_2m_max,temperature_2m_min",
+                "forecast_days": 7,
+                "temperature_unit": "fahrenheit",
+                "timezone": "America/Chicago",
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError:
+        return HTMLResponse(
+            "Failed to fetch forecast data. Please try again later.",
+            status_code=status.HTTP_502_BAD_GATEWAY,
+        )
     data = response.json()
     forecast = list(
         zip(
@@ -61,19 +67,25 @@ def nashville_detailed_forecast(
     request: Request, user: models.User = Depends(get_current_user)
 ):
     """Return Nashville's 7 day detailed weather forecast as a web page."""
-    response = httpx.get(
-        "https://api.open-meteo.com/v1/forecast",
-        params={
-            "latitude": 36.1627,
-            "longitude": -86.7816,
-            "daily": "weathercode,temperature_2m_max,temperature_2m_min,precipitation_probability_max",
-            "forecast_days": 7,
-            "temperature_unit": "fahrenheit",
-            "timezone": "America/Chicago",
-        },
-        timeout=10,
-    )
-    response.raise_for_status()
+    try:
+        response = httpx.get(
+            "https://api.open-meteo.com/v1/forecast",
+            params={
+                "latitude": 36.1627,
+                "longitude": -86.7816,
+                "daily": "weathercode,temperature_2m_max,temperature_2m_min,precipitation_probability_max",
+                "forecast_days": 7,
+                "temperature_unit": "fahrenheit",
+                "timezone": "America/Chicago",
+            },
+            timeout=10,
+        )
+        response.raise_for_status()
+    except httpx.HTTPError:
+        return HTMLResponse(
+            "Failed to fetch forecast data. Please try again later.",
+            status_code=status.HTTP_502_BAD_GATEWAY,
+        )
     data = response.json()
     forecast = [
         (

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -111,3 +111,37 @@ def test_nashville_detailed_forecast_requires_login(monkeypatch, client):
     assert response.status_code == 303
     assert response.headers["location"].startswith("/login")
     assert "error=Please%20log%20in%20to%20access%20that%20page" in response.headers["location"]
+
+
+def test_nashville_forecast_httpx_error(monkeypatch, client):
+    """Return 502 when the upstream service fails for basic forecast."""
+
+    def mock_get(*args, **kwargs):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    username = "errbasic"
+    password = "secret"
+    login_helper(client, username, password)
+
+    response = client.get("/forecast/nashville")
+    assert response.status_code == 502
+    assert "Failed to fetch forecast data" in response.text
+
+
+def test_nashville_detailed_forecast_httpx_error(monkeypatch, client):
+    """Return 502 when the upstream service fails for detailed forecast."""
+
+    def mock_get(*args, **kwargs):
+        raise httpx.HTTPError("boom")
+
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    username = "errdetail"
+    password = "secret"
+    login_helper(client, username, password)
+
+    response = client.get("/forecast/nashville/detailed")
+    assert response.status_code == 502
+    assert "Failed to fetch forecast data" in response.text


### PR DESCRIPTION
## Summary
- handle `httpx` failures in forecast routes
- return 502 responses when the upstream API is unreachable
- test forecast error handling

## Testing
- `source venv/bin/activate`
- `PYTHONPATH=. pytest -q`