### PR TITLE
Enable SQLite persistence via Docker volume

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 venv/
 __pycache__/
 *.db
+data/

--- a/README.md
+++ b/README.md
@@ -49,6 +49,15 @@ docker run -e DATABASE_URL=postgresql://postgres:postgres@db:5432/postgres \
   -p 8000:80 codex-playground
 ```
 
+To keep the default SQLite database across container restarts, mount a host
+directory and point `DATABASE_URL` to that location:
+
+```bash
+docker run -v $(pwd)/data:/data \
+  -e DATABASE_URL=sqlite:////data/test.db \
+  -p 8000:80 codex-playground
+```
+
 The example above expects a PostgreSQL instance reachable at the hostname `db`. For local development you can run a Postgres container with:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,10 @@ services:
     ports:
       - "80:80"
     restart: unless-stopped
+    volumes:
+      - ./data:/data
+    environment:
+      - DATABASE_URL=sqlite:////data/test.db
     # Optional: if you use environment variables
     # env_file:
     #   - .env


### PR DESCRIPTION
## Summary
- document how to mount a host directory so SQLite data survives container rebuilds
- persist `test.db` using a volume and environment variable in `docker-compose.yml`
- ignore any local `data/` directory

## Testing
- `source venv/bin/activate && PYTHONPATH=. pytest -q`