### PR TITLE
Add random turtle photo page

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ This repository contains a small FastAPI application with user authentication.
 - Protected page that greets authenticated users
 - Dark mode toggle available from the account settings page
 - Random dog photo page for logged in users
+- Random turtle photo page for logged in users
 - Nashville weather forecast including a detailed view
 
 ## Development

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -31,6 +31,17 @@ def random_dog(request: Request, user: models.User = Depends(get_current_user)):
     )
 
 
+@router.get("/turtles", response_class=HTMLResponse)
+def random_turtle(
+    request: Request, user: models.User = Depends(get_current_user)
+):
+    turtle_url = f"https://source.unsplash.com/300x300/?turtle&{int(time.time())}"
+    return templates.TemplateResponse(
+        "turtle.html",
+        {"request": request, "turtle_url": turtle_url},
+    )
+
+
 @router.get("/account", response_class=HTMLResponse)
 def account_page(request: Request, user: models.User = Depends(get_current_user)):
     return templates.TemplateResponse(

--- a/templates/sidebar.html
+++ b/templates/sidebar.html
@@ -1,6 +1,7 @@
 <div class="sidebar">
   <p><a href="/forecast/nashville">Nashville Forecast</a></p>
   <p><a href="/dogs">Random Dog</a></p>
+  <p><a href="/turtles">Random Turtle</a></p>
   <p><a href="/account">Account Settings</a></p>
   <p><a href="/suggestions">Suggestion Box</a></p>
 </div>

--- a/templates/turtle.html
+++ b/templates/turtle.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block title %}Random Turtle{% endblock %}
+{% block content %}
+  <div class="success-container">
+    <h1>Random Turtle Photo</h1>
+    <div id="spinner" class="spinner"></div>
+    <img
+        id="turtle-photo"
+        src="{{ turtle_url }}"
+        alt="Random Turtle"
+        width="300"
+        height="300"
+        style="object-fit: cover; display: none;"
+    />
+  </div>
+{% endblock %}
+{% block scripts %}
+<script>
+  const img = document.getElementById('turtle-photo');
+  const spinner = document.getElementById('spinner');
+  if (img && spinner) {
+    spinner.style.display = 'block';
+    img.addEventListener('load', () => {
+      spinner.style.display = 'none';
+      img.style.display = 'block';
+    });
+  }
+</script>
+{% endblock %}

--- a/tests/test_pages_redirects.py
+++ b/tests/test_pages_redirects.py
@@ -11,3 +11,9 @@ def test_dogs_redirects_to_login(client):
     response = client.get("/dogs", follow_redirects=False)
     assert response.status_code == 303
     assert response.headers["location"].startswith("/login")
+
+
+def test_turtles_redirects_to_login(client):
+    response = client.get("/turtles", follow_redirects=False)
+    assert response.status_code == 303
+    assert response.headers["location"].startswith("/login")

--- a/tests/test_turtle_photo.py
+++ b/tests/test_turtle_photo.py
@@ -1,0 +1,22 @@
+import re
+from conftest import login_helper
+
+
+def test_turtle_photo_display_after_login(client):
+    username = "turtleuser"
+    password = "secret"
+
+    login_helper(client, username, password)
+
+    response = client.get("/turtles")
+    assert response.status_code == 200
+    assert 'id="turtle-photo"' in response.text
+    assert 'id="spinner"' in response.text
+    match = re.search(r'<img[^>]*id="turtle-photo"[^>]*>', response.text)
+    assert match, "turtle photo img tag not found"
+    tag = match.group(0)
+    src_match = re.search(r'src="([^"]+)"', tag)
+    assert src_match, "src attribute not found"
+    assert src_match.group(1).startswith("https://")
+    assert 'width="300"' in tag
+    assert 'height="300"' in tag


### PR DESCRIPTION
## Summary
- implement `/turtles` endpoint and template
- link turtle page in sidebar
- add tests for turtle photo and redirect behavior
- document turtle page in README

## Testing
- `source venv/bin/activate && PYTHONPATH=. pytest -q`