### PR TITLE
Highlight today in forecast

### DIFF
--- a/app/routes/forecast.py
+++ b/app/routes/forecast.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Depends, Request, status
 from fastapi.responses import HTMLResponse
 import httpx
-
 from .. import models
 from ..dependencies import get_current_user, templates
 
@@ -97,6 +96,7 @@ def _render_forecast(request: Request, slug: str, detailed: bool):
             )
         )
         template = "forecast.html"
+    today = forecast[0][0] if forecast else ""
 
     return templates.TemplateResponse(
         template,
@@ -105,6 +105,7 @@ def _render_forecast(request: Request, slug: str, detailed: bool):
             "forecast": forecast,
             "city_name": city["name"],
             "slug": slug,
+            "today": today,
             "cities": {k: v["name"] for k, v in CITIES.items()},
         },
     )

--- a/static/styles.css
+++ b/static/styles.css
@@ -104,6 +104,12 @@ th, td {
     border: 1px solid #ccc;
     padding: 0.5rem;
 }
+.today-row {
+    background-color: #ffffcc;
+}
+.dark-mode .today-row {
+    background-color: #555555;
+}
 a {
     color: var(--link-color);
 }

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -24,7 +24,11 @@
       </thead>
       <tbody>
         {% for date, high, low in forecast %}
-        <tr><td>{{ date }}</td><td>{{ high }}&deg;F</td><td>{{ low }}&deg;F</td></tr>
+        <tr{% if date == today %} class="today-row"{% endif %}>
+          <td>{{ date }}</td>
+          <td>{{ high }}&deg;F</td>
+          <td>{{ low }}&deg;F</td>
+        </tr>
         {% endfor %}
       </tbody>
     </table>

--- a/templates/forecast_detail.html
+++ b/templates/forecast_detail.html
@@ -30,7 +30,7 @@
       </thead>
       <tbody>
         {% for date, condition, high, low, precip in forecast %}
-        <tr>
+        <tr{% if date == today %} class="today-row"{% endif %}>
           <td>{{ date }}</td>
           <td>{{ condition }}</td>
           <td>{{ high }}&deg;F</td>

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -46,6 +46,7 @@ def test_forecast_endpoint(monkeypatch, client, slug, lat, lon):
     assert response.status_code == 200
     assert f"{CITIES[slug]['name']} 7-Day Forecast" in response.text
     assert expected["daily"]["time"][0] in response.text
+    assert 'class="today-row"' in response.text
     assert 'id="city-select"' in response.text
     for s in CITIES:
         assert f'<option value="{s}"' in response.text
@@ -102,6 +103,7 @@ def test_detailed_forecast_endpoint(monkeypatch, client, slug, lat, lon):
     assert "30%" in response.text
     assert 'id="city-select"' in response.text
     assert "detailedForecast" in response.text
+    assert 'class="today-row"' in response.text
 
 
 @pytest.mark.parametrize("path", [


### PR DESCRIPTION
## Summary
- mark today's row when rendering forecasts
- style highlighted rows
- test that forecasts include highlighting

## Testing
- `source venv/bin/activate`
- `PYTHONPATH=. pytest -q`