### PR TITLE
Add persistent user preferences

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,11 +7,13 @@ from sqlalchemy.orm import Session
 
 from . import auth, models
 from .database import Base, engine, get_db
+from .user_settings import get_user_settings
 from .routes import (
     auth as auth_routes,
     forecast as forecast_routes,
     pages as pages_routes,
     suggestions as suggestions_routes,
+    settings as settings_routes,
 )
 from .dependencies import templates
 
@@ -22,8 +24,10 @@ def create_default_user(db: Session) -> None:
     """Create a default user if one does not already exist."""
     if not db.query(models.User).filter(models.User.username == "test").first():
         hashed = auth.get_password_hash("test")
-        db.add(models.User(username="test", hashed_password=hashed))
+        user = models.User(username="test", hashed_password=hashed)
+        db.add(user)
         db.commit()
+        get_user_settings(db, user.id)
 
 
 app = FastAPI()
@@ -60,3 +64,4 @@ app.include_router(auth_routes.router)
 app.include_router(forecast_routes.router)
 app.include_router(pages_routes.router)
 app.include_router(suggestions_routes.router)
+app.include_router(settings_routes.router)

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, ForeignKey, DateTime
+from sqlalchemy import Column, Integer, String, ForeignKey, DateTime, Boolean
 from sqlalchemy.orm import relationship
 from datetime import datetime
 
@@ -23,3 +23,18 @@ class Suggestion(Base):
     timestamp = Column(DateTime, default=datetime.utcnow, nullable=False)
 
     user = relationship("User")
+
+
+class UserSettings(Base):
+    """Per-user persistent settings."""
+
+    __tablename__ = "user_settings"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), unique=True, nullable=False)
+    dark_mode = Column(Boolean, default=False, nullable=False)
+    detailed_forecast = Column(Boolean, default=False, nullable=False)
+    preferred_city = Column(String, default="nashville", nullable=False)
+    preferred_animal = Column(String, default="cat", nullable=False)
+
+    user = relationship("User", backref="settings", uselist=False)

--- a/app/routes/auth.py
+++ b/app/routes/auth.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 from .. import auth, models
 from ..database import get_db
 from ..dependencies import templates
+from ..user_settings import get_user_settings
 
 router = APIRouter()
 
@@ -26,6 +27,8 @@ def signup(
     user = models.User(username=username, hashed_password=hashed_password)
     db.add(user)
     db.commit()
+    db.refresh(user)
+    get_user_settings(db, user.id)
     return RedirectResponse(url="/login", status_code=303)
 
 

--- a/app/routes/pages.py
+++ b/app/routes/pages.py
@@ -5,6 +5,9 @@ from ..random_animal import RandomAnimalHandler
 
 from .. import models
 from ..dependencies import get_current_user, templates
+from ..database import get_db
+from sqlalchemy.orm import Session
+from ..user_settings import get_user_settings
 
 _animal_handler = RandomAnimalHandler()
 
@@ -19,10 +22,18 @@ def root(request: Request):
 @router.get("/protected", response_class=HTMLResponse)
 def protected(
     request: Request,
-    animal: str = "cat",
+    animal: str | None = None,
     user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
 ):
-    animal, url = _animal_handler.get_animal_url(animal)
+    settings = get_user_settings(db, user.id)
+    selected = animal or settings.preferred_animal
+    if animal:
+        settings.preferred_animal = selected
+        db.commit()
+    animal, url = _animal_handler.get_animal_url(selected)
+    settings.preferred_animal = animal
+    db.commit()
     return templates.TemplateResponse(
         "success.html",
         {
@@ -30,6 +41,9 @@ def protected(
             "username": user.username,
             "animal_url": url,
             "animal": animal,
+            "dark_mode": settings.dark_mode,
+            "detailed": settings.detailed_forecast,
+            "preferred_animal": settings.preferred_animal,
         },
     )
 
@@ -37,7 +51,18 @@ def protected(
 
 
 @router.get("/account", response_class=HTMLResponse)
-def account_page(request: Request, user: models.User = Depends(get_current_user)):
+def account_page(
+    request: Request,
+    user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    settings = get_user_settings(db, user.id)
     return templates.TemplateResponse(
-        "account.html", {"request": request, "username": user.username}
+        "account.html",
+        {
+            "request": request,
+            "username": user.username,
+            "dark_mode": settings.dark_mode,
+            "detailed": settings.detailed_forecast,
+        },
     )

--- a/app/routes/settings.py
+++ b/app/routes/settings.py
@@ -1,0 +1,45 @@
+from fastapi import APIRouter, Depends, Form
+from sqlalchemy.orm import Session
+
+from .. import models
+from ..database import get_db
+from ..dependencies import get_current_user
+from ..user_settings import get_user_settings
+
+router = APIRouter()
+
+
+@router.get("/settings")
+def read_settings(
+    user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    settings = get_user_settings(db, user.id)
+    return {
+        "dark_mode": settings.dark_mode,
+        "detailed_forecast": settings.detailed_forecast,
+        "preferred_city": settings.preferred_city,
+        "preferred_animal": settings.preferred_animal,
+    }
+
+
+@router.post("/settings")
+def update_settings(
+    dark_mode: bool | None = Form(None),
+    detailed_forecast: bool | None = Form(None),
+    preferred_city: str | None = Form(None),
+    preferred_animal: str | None = Form(None),
+    user: models.User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+):
+    settings = get_user_settings(db, user.id)
+    if dark_mode is not None:
+        settings.dark_mode = dark_mode
+    if detailed_forecast is not None:
+        settings.detailed_forecast = detailed_forecast
+    if preferred_city:
+        settings.preferred_city = preferred_city
+    if preferred_animal:
+        settings.preferred_animal = preferred_animal
+    db.commit()
+    return {"success": True}

--- a/app/user_settings.py
+++ b/app/user_settings.py
@@ -1,0 +1,14 @@
+from sqlalchemy.orm import Session
+
+from . import models
+
+
+def get_user_settings(db: Session, user_id: int) -> models.UserSettings:
+    """Return a user's settings row, creating defaults if needed."""
+    settings = db.query(models.UserSettings).filter_by(user_id=user_id).first()
+    if not settings:
+        settings = models.UserSettings(user_id=user_id)
+        db.add(settings)
+        db.commit()
+        db.refresh(settings)
+    return settings

--- a/templates/account.html
+++ b/templates/account.html
@@ -6,14 +6,14 @@
     <p>Username: {{ username }}</p>
     <div class="toggle-row">
       <label class="switch">
-        <input type="checkbox" id="toggle-dark" />
+        <input type="checkbox" id="toggle-dark" {% if dark_mode %}checked{% endif %} />
         <span class="slider round"></span>
       </label>
       <span>Dark Mode</span>
     </div>
     <div class="toggle-row">
       <label class="switch">
-        <input type="checkbox" id="toggle-detailed" />
+        <input type="checkbox" id="toggle-detailed" {% if detailed %}checked{% endif %} />
         <span class="slider round"></span>
       </label>
       <span>Detailed Forecast</span>
@@ -22,21 +22,35 @@
 {% endblock %}
 {% block scripts %}
 <script>
-  function applyDetailedState() {
-    const enabled = localStorage.getItem('detailedForecast') === 'true';
-    const box = document.getElementById('toggle-detailed');
-    if (box) {
-      box.checked = enabled;
-    }
-  }
+  document.addEventListener('DOMContentLoaded', () => {
+    localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
+    localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
 
-  applyDetailedState();
-  const detailedToggle = document.getElementById('toggle-detailed');
-  if (detailedToggle) {
-    detailedToggle.addEventListener('change', () => {
-      const enabled = detailedToggle.checked;
-      localStorage.setItem('detailedForecast', enabled);
-    });
-  }
+    const darkToggle = document.getElementById('toggle-dark');
+    if (darkToggle) {
+      darkToggle.addEventListener('change', () => {
+        const enabled = darkToggle.checked;
+        localStorage.setItem('darkMode', enabled);
+        fetch('/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: 'dark_mode=' + enabled
+        });
+      });
+    }
+
+    const detailedToggle = document.getElementById('toggle-detailed');
+    if (detailedToggle) {
+      detailedToggle.addEventListener('change', () => {
+        const enabled = detailedToggle.checked;
+        localStorage.setItem('detailedForecast', enabled);
+        fetch('/settings', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+          body: 'detailed_forecast=' + enabled
+        });
+      });
+    }
+  });
 </script>
 {% endblock %}

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -2,9 +2,7 @@
 {% block title %}{{ city_name }} Forecast{% endblock %}
 {% block head_scripts %}
 <script>
-  if (localStorage.getItem('detailedForecast') === 'true') {
-    window.location.replace('/forecast/{{ slug }}/detailed');
-  }
+  localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
 </script>
 {% endblock %}
 {% block content %}
@@ -40,10 +38,16 @@
   if (select) {
     select.addEventListener('change', () => {
       const slug = select.value;
-      const path = localStorage.getItem('detailedForecast') === 'true'
-        ? `/forecast/${slug}/detailed`
-        : `/forecast/${slug}`;
-      window.location.replace(path);
+      fetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'preferred_city=' + slug
+      }).then(() => {
+        const path = localStorage.getItem('detailedForecast') === 'true'
+          ? `/forecast/${slug}/detailed`
+          : `/forecast/${slug}`;
+        window.location.replace(path);
+      });
     });
   }
 </script>

--- a/templates/forecast_detail.html
+++ b/templates/forecast_detail.html
@@ -2,9 +2,7 @@
 {% block title %}{{ city_name }} Detailed Forecast{% endblock %}
 {% block head_scripts %}
 <script>
-  if (localStorage.getItem('detailedForecast') !== 'true') {
-    window.location.replace('/forecast/{{ slug }}');
-  }
+  localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
 </script>
 {% endblock %}
 {% block content %}
@@ -48,10 +46,16 @@
   if (select) {
     select.addEventListener('change', () => {
       const slug = select.value;
-      const path = localStorage.getItem('detailedForecast') === 'true'
-        ? `/forecast/${slug}/detailed`
-        : `/forecast/${slug}`;
-      window.location.replace(path);
+      fetch('/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: 'preferred_city=' + slug
+      }).then(() => {
+        const path = localStorage.getItem('detailedForecast') === 'true'
+          ? `/forecast/${slug}/detailed`
+          : `/forecast/${slug}`;
+        window.location.replace(path);
+      });
     });
   }
 </script>

--- a/templates/success.html
+++ b/templates/success.html
@@ -35,12 +35,12 @@
 
   const select = document.getElementById('animal-select');
   document.addEventListener('DOMContentLoaded', () => {
+    localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
+    localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
+
     const current = '{{ animal }}';
-    let stored = localStorage.getItem('preferredAnimal');
-    if (!stored) {
-      stored = current;
-      localStorage.setItem('preferredAnimal', stored);
-    }
+    let stored = '{{ preferred_animal }}';
+    localStorage.setItem('preferredAnimal', stored);
     select.value = stored;
     if (stored !== current) {
       window.location.search = `?animal=${stored}`;
@@ -50,7 +50,13 @@
   select.addEventListener('change', () => {
     const val = select.value;
     localStorage.setItem('preferredAnimal', val);
-    window.location.search = `?animal=${val}`;
+    fetch('/settings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'preferred_animal=' + val
+    }).then(() => {
+      window.location.search = `?animal=${val}`;
+    });
   });
 </script>
 {% endblock %}

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -1,0 +1,36 @@
+from conftest import login_helper, TestingSessionLocal
+from app import models
+
+
+def _get_settings(username):
+    with TestingSessionLocal() as db:
+        user = db.query(models.User).filter(models.User.username == username).first()
+        return db.query(models.UserSettings).filter(models.UserSettings.user_id == user.id).first()
+
+
+def test_settings_created_on_signup(client):
+    username = "prefuser"
+    password = "secret"
+    login_helper(client, username, password)
+    settings = _get_settings(username)
+    assert settings is not None
+    assert settings.preferred_animal == "cat"
+    assert settings.preferred_city == "nashville"
+    assert settings.detailed_forecast is False
+    assert settings.dark_mode is False
+
+
+def test_settings_persist(client):
+    username = "prefs"
+    password = "secret"
+    login_helper(client, username, password)
+    client.get("/protected?animal=dog")
+    client.get("/forecast/holts-summit/detailed")
+    settings = _get_settings(username)
+    assert settings.preferred_animal == "dog"
+    assert settings.preferred_city == "holts-summit"
+    assert settings.detailed_forecast is True
+    client.get("/logout")
+    login_helper(client, username, password)
+    response = client.get("/account")
+    assert 'id="toggle-detailed" checked' in response.text


### PR DESCRIPTION
## Summary
- track per-user settings in a new `UserSettings` model
- helper for retrieving/creating settings
- endpoints to read and update settings
- save preferences when viewing protected pages or forecasts
- expose settings in templates and sync them via JS
- tests for settings persistence

## Testing
- `source venv/bin/activate && PYTHONPATH=. pytest -q`