### PR TITLE
Fix forecast preference persistence

### DIFF
--- a/app/routes/forecast.py
+++ b/app/routes/forecast.py
@@ -126,7 +126,8 @@ def nashville_forecast(
     db: Session = Depends(get_db),
 ):
     """Return Nashville's 7 day weather forecast as a web page."""
-    return _render_forecast(request, "nashville", False, user, db)
+    settings = get_user_settings(db, user.id)
+    return _render_forecast(request, "nashville", settings.detailed_forecast, user, db)
 
 
 @router.get("/forecast/nashville/detailed", response_class=HTMLResponse)
@@ -146,7 +147,8 @@ def holts_summit_forecast(
     db: Session = Depends(get_db),
 ):
     """Return Holts Summit's 7 day weather forecast as a web page."""
-    return _render_forecast(request, "holts-summit", False, user, db)
+    settings = get_user_settings(db, user.id)
+    return _render_forecast(request, "holts-summit", settings.detailed_forecast, user, db)
 
 
 @router.get("/forecast/holts-summit/detailed", response_class=HTMLResponse)

--- a/tests/test_user_settings.py
+++ b/tests/test_user_settings.py
@@ -1,3 +1,4 @@
+import httpx
 from conftest import login_helper, TestingSessionLocal
 from app import models
 
@@ -34,3 +35,46 @@ def test_settings_persist(client):
     login_helper(client, username, password)
     response = client.get("/account")
     assert 'id="toggle-detailed" checked' in response.text
+
+
+def test_forecast_respects_saved_setting(monkeypatch, client):
+    expected = {
+        "daily": {
+            "time": ["2025-05-20"],
+            "weathercode": [2],
+            "temperature_2m_max": [70],
+            "temperature_2m_min": [50],
+            "precipitation_probability_max": [30],
+        }
+    }
+
+    class MockResponse:
+        def __init__(self, data):
+            self._data = data
+
+        def json(self):
+            return self._data
+
+        def raise_for_status(self):
+            pass
+
+    def mock_get(url, params=None, timeout=None):
+        assert url == "https://api.open-meteo.com/v1/forecast"
+        assert "weathercode" in params["daily"]
+        return MockResponse(expected)
+
+    monkeypatch.setattr(httpx, "get", mock_get)
+
+    username = "detailpref"
+    password = "secret"
+    login_helper(client, username, password)
+
+    client.post(
+        "/settings",
+        data={"detailed_forecast": True},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    response = client.get("/forecast/nashville")
+    assert response.status_code == 200
+    assert "Nashville Detailed Forecast" in response.text


### PR DESCRIPTION
## Summary
- load the user's saved `detailed_forecast` setting when visiting the
  standard forecast routes
- add regression test ensuring saved preference renders the detailed view

## Testing
- `source venv/bin/activate && PYTHONPATH=. pytest -q`