### PR TITLE
Fix persistent user settings

### DIFF
--- a/app/routes/forecast.py
+++ b/app/routes/forecast.py
@@ -115,6 +115,7 @@ def _render_forecast(request: Request, slug: str, detailed: bool, user: models.U
             "today": today,
             "cities": {k: v["name"] for k, v in CITIES.items()},
             "detailed": settings.detailed_forecast,
+            "dark_mode": settings.dark_mode,
         },
     )
 

--- a/app/routes/suggestions.py
+++ b/app/routes/suggestions.py
@@ -7,6 +7,7 @@ from sqlalchemy.orm import Session
 from .. import models
 from ..database import get_db
 from ..dependencies import get_current_user, templates
+from ..user_settings import get_user_settings
 
 router = APIRouter()
 
@@ -22,9 +23,16 @@ def view_suggestions(
         .order_by(models.Suggestion.timestamp.desc())
         .all()
     )
+    settings = get_user_settings(db, user.id)
     return templates.TemplateResponse(
         "suggestions.html",
-        {"request": request, "suggestions": suggestions, "username": user.username},
+        {
+            "request": request,
+            "suggestions": suggestions,
+            "username": user.username,
+            "dark_mode": settings.dark_mode,
+            "detailed": settings.detailed_forecast,
+        },
     )
 
 

--- a/templates/account.html
+++ b/templates/account.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 {% block title %}Account Settings{% endblock %}
+{% block head_scripts %}
+  {{ super() }}
+  <script>
+    localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
+    localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
+  </script>
+{% endblock %}
 {% block content %}
   <div class="account-container">
     <h1>Account Settings</h1>
@@ -23,8 +30,6 @@
 {% block scripts %}
 <script>
   document.addEventListener('DOMContentLoaded', () => {
-    localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
-    localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
 
     const darkToggle = document.getElementById('toggle-dark');
     if (darkToggle) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -3,6 +3,16 @@
   <head>
     <title>{% block title %}{% endblock %}</title>
     {% block head_scripts %}{% endblock %}
+    {% if dark_mode is defined %}
+    <script>
+      localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
+    </script>
+    {% endif %}
+    {% if detailed is defined %}
+    <script>
+      localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
+    </script>
+    {% endif %}
     <link rel="stylesheet" href="/static/styles.css" />
   </head>
   <body>

--- a/templates/forecast.html
+++ b/templates/forecast.html
@@ -3,6 +3,9 @@
 {% block head_scripts %}
 <script>
   localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
+  {% if dark_mode is defined %}
+  localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
+  {% endif %}
 </script>
 {% endblock %}
 {% block content %}

--- a/templates/forecast_detail.html
+++ b/templates/forecast_detail.html
@@ -3,6 +3,9 @@
 {% block head_scripts %}
 <script>
   localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
+  {% if dark_mode is defined %}
+  localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
+  {% endif %}
 </script>
 {% endblock %}
 {% block content %}

--- a/templates/success.html
+++ b/templates/success.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 {% block title %}Success{% endblock %}
+{% block head_scripts %}
+  {{ super() }}
+  <script>
+    localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
+    localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
+  </script>
+{% endblock %}
 {% block content %}
   <div class="success-container">
     <h1>Congrats! You signed in!</h1>
@@ -34,9 +41,6 @@
 
   const select = document.getElementById('animal-select');
   document.addEventListener('DOMContentLoaded', () => {
-    localStorage.setItem('darkMode', {{ 'true' if dark_mode else 'false' }});
-    localStorage.setItem('detailedForecast', {{ 'true' if detailed else 'false' }});
-
     const current = '{{ animal }}';
     let stored = '{{ preferred_animal }}';
     localStorage.setItem('preferredAnimal', stored);

--- a/tests/test_forecast.py
+++ b/tests/test_forecast.py
@@ -52,6 +52,7 @@ def test_forecast_endpoint(monkeypatch, client, slug, lat, lon):
         assert f'<option value="{s}"' in response.text
     assert f'<option value="{slug}" selected' in response.text
     assert "detailedForecast" in response.text
+    assert "localStorage.setItem('darkMode'" in response.text
 
 
 @pytest.mark.parametrize(
@@ -104,6 +105,7 @@ def test_detailed_forecast_endpoint(monkeypatch, client, slug, lat, lon):
     assert 'id="city-select"' in response.text
     assert "detailedForecast" in response.text
     assert 'class="today-row"' in response.text
+    assert "localStorage.setItem('darkMode'" in response.text
 
 
 @pytest.mark.parametrize("path", [

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -40,3 +40,5 @@ def test_suggestion_submission_and_display(client):
     assert "Suggestion Box" in response.text
     assert '<a href="/suggestions">Suggestion Box</a>' in response.text
     assert '<div class="suggestion-container">' in response.text
+    assert "localStorage.setItem('darkMode'" in response.text
+    assert "localStorage.setItem('detailedForecast'" in response.text


### PR DESCRIPTION
## Summary
- store dark mode and forecast preference early in `base.html`
- include user settings on suggestions and forecast pages
- update templates to set localStorage before `darkmode.js`
- test that suggestions and forecast pages include dark mode script

## Testing
- `source venv/bin/activate`
- `PYTHONPATH=. pytest -q`